### PR TITLE
Filter moved and refactored

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2048,9 +2048,9 @@
       }
     },
     "@nrwl/nx-cloud": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-cloud/-/nx-cloud-14.1.3.tgz",
-      "integrity": "sha512-8Kn2xeKLTnifsZrNimOwl8Q1dJUWx+HwOC/0MeFgTySKcKE0eim81ST8xiaysNw6EyYT6y/vhPGMxby22wtqYQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-cloud/-/nx-cloud-14.3.0.tgz",
+      "integrity": "sha512-aByHe8Gp1/IT9CtQYlGLIYBgU+ZtrgEwblBX8kcoBNRPf1OOdouahjyasAjQ9zi1cznve8AzTTcLt2eSCHWfrw==",
       "dev": true,
       "requires": {
         "axios": "^0.21.1",
@@ -4467,6 +4467,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -10195,6 +10200,15 @@
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "react-sortablejs": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/react-sortablejs/-/react-sortablejs-6.1.4.tgz",
+      "integrity": "sha512-fc7cBosfhnbh53Mbm6a45W+F735jwZ1UFIYSrIqcO/gRIFoDyZeMtgKlpV4DdyQfbCzdh5LoALLTDRxhMpTyXQ==",
+      "requires": {
+        "classnames": "2.3.1",
+        "tiny-invariant": "1.2.0"
+      }
+    },
     "react-table": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
@@ -10956,6 +10970,11 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "sortablejs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11528,6 +11547,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "react-dom": "18.2.0",
     "react-is": "18.2.0",
     "react-router-dom": "6.3.0",
+    "react-sortablejs": "^6.1.4",
     "react-table": "^7.8.0",
     "react-virtual": "^2.10.4",
     "react-window": "^1.8.7",
     "regenerator-runtime": "0.13.7",
+    "sortablejs": "^1.15.0",
     "styled-components": "5.3.5",
     "tslib": "^2.3.0",
     "typesafe-actions": "^5.1.0"

--- a/packages/filter/.babelrc
+++ b/packages/filter/.babelrc
@@ -1,0 +1,12 @@
+{
+    "presets": [
+        [
+            "@nrwl/react/babel",
+            {
+                "runtime": "automatic",
+                "useBuiltIns": "usage"
+            }
+        ]
+    ],
+    "plugins": [["styled-components", { "pure": true, "ssr": true }]]
+}

--- a/packages/filter/.eslintrc.json
+++ b/packages/filter/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["plugin:@nrwl/nx/react", "../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        }
+    ]
+}

--- a/packages/filter/README.md
+++ b/packages/filter/README.md
@@ -1,0 +1,7 @@
+# filter
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test filter` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/filter/jest.config.ts
+++ b/packages/filter/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+    displayName: 'filter',
+    preset: '../../jest.preset.js',
+    transform: {
+        '^.+\\.[tj]sx?$': 'babel-jest',
+    },
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    coverageDirectory: '../../coverage/packages/filter',
+};

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "@equinor/filter",
+    "version": "0.0.1"
+}

--- a/packages/filter/project.json
+++ b/packages/filter/project.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "..\\..\\node_modules\\nx\\schemas\\project-schema.json",
+    "sourceRoot": "packages/filter/src",
+    "projectType": "library",
+    "tags": [],
+    "targets": {
+        "build": {
+            "executor": "@nrwl/web:rollup",
+            "outputs": [
+                "{options.outputPath}"
+            ],
+            "options": {
+                "outputPath": "dist/packages/filter",
+                "tsConfig": "packages/filter/tsconfig.lib.json",
+                "project": "packages/filter/package.json",
+                "entryFile": "packages/filter/src/index.ts",
+                "external": [
+                    "react/jsx-runtime"
+                ],
+                "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+                "compiler": "babel",
+                "assets": [
+                    {
+                        "glob": "packages/filter/README.md",
+                        "input": ".",
+                        "output": "."
+                    }
+                ]
+            }
+        },
+        "publish": {
+            "executor": "@nrwl/workspace:run-commands",
+            "options": {
+                "command": "node tools/scripts/publish.mjs filter {args.ver} {args.tag}"
+            },
+            "dependsOn": [
+                {
+                    "projects": "self",
+                    "target": "build"
+                }
+            ]
+        },
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": [
+                "{options.outputFile}"
+            ],
+            "options": {
+                "lintFilePatterns": [
+                    "packages/filter/**/*.{ts,tsx,js,jsx}"
+                ]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": [
+                "coverage/packages/filter"
+            ],
+            "options": {
+                "jestConfig": "packages/filter/jest.config.ts",
+                "passWithNoTests": true
+            }
+        }
+    }
+}

--- a/packages/filter/src/index.ts
+++ b/packages/filter/src/index.ts
@@ -1,0 +1,5 @@
+export * from './lib/classes';
+export * from './lib/functions';
+export * from './lib/types';
+export * from './lib/utils';
+export * from './lib/components';

--- a/packages/filter/src/lib/classes/FilterController.ts
+++ b/packages/filter/src/lib/classes/FilterController.ts
@@ -8,34 +8,21 @@ import {
 import { registerCallback } from '../functions/registerCallback';
 
 import {
+    Callback,
     FilterGroup,
     FilterItemCount,
     FilterSearchActive,
     FilterValueType,
+    OnCallbackSet,
+    OnFilterDataChangeCallback,
+    OnFilterStateChangedCallback,
     ValueFormatterFilter,
     ValueFormatterFunction,
 } from '../types';
 import { filterGroupExists } from '../utils';
 
-export type OnFilterDataChangeCallback<TData> = (
-    data: TData[],
-    controller: FilterController<TData>
-) => void;
 
-export type OnFilterStateChangedCallback<T> = (
-    newFilterState: FilterGroup[],
-    controller: FilterController<T>
-) => void;
 
-export interface Callback<TCallback> {
-    id: string;
-    callback: TCallback;
-}
-
-export interface OnCallbackSet {
-    id: string;
-    unSubscribe: () => void;
-}
 
 //TODO: Add change handlers to everything
 export class FilterController<TData> {
@@ -86,12 +73,20 @@ export class FilterController<TData> {
         this.valueFormatters = [...this.valueFormatters, ...valueFormatters];
     };
 
+    /**
+     * Check if a value is currently being filtered out from the dataset
+     */
     checkValueIsInactive = (groupName: string, value: FilterValueType) =>
         Boolean(this.filterState.find(({ name }) => name === groupName)?.values.includes(value));
 
     getGroupValues = (groupName: string) =>
         this.allFilterValues.find(({ name }) => name === groupName)?.values ?? [];
 
+    /**
+    * Get all the values that are currently being filtered out from a specific group
+    * @param groupName 
+    * @returns 
+    */
     getInactiveGroupValues = (groupName: string) =>
         this.filterState.find(({ name }) => name === groupName)?.values ?? [];
 

--- a/packages/filter/src/lib/classes/FilterController.ts
+++ b/packages/filter/src/lib/classes/FilterController.ts
@@ -1,0 +1,264 @@
+import {
+    doesItemPassCriteria,
+    doesItemPassFilter,
+    generateFilterValues,
+    searchForIncludes,
+    searchForStartsWith,
+} from '../functions';
+import { registerCallback } from '../functions/registerCallback';
+
+import {
+    FilterGroup,
+    FilterItemCount,
+    FilterSearchActive,
+    FilterValueType,
+    ValueFormatterFilter,
+    ValueFormatterFunction,
+} from '../types';
+import { filterGroupExists } from '../utils';
+
+export type OnFilterDataChangeCallback<TData> = (
+    data: TData[],
+    controller: FilterController<TData>
+) => void;
+
+export type OnFilterStateChangedCallback<T> = (
+    newFilterState: FilterGroup[],
+    controller: FilterController<T>
+) => void;
+
+export interface Callback<TCallback> {
+    id: string;
+    callback: TCallback;
+}
+
+export interface OnCallbackSet {
+    id: string;
+    unSubscribe: () => void;
+}
+
+//TODO: Add change handlers to everything
+export class FilterController<TData> {
+    data: TData[] = [];
+    filteredData: TData[] = [];
+    filterState: FilterGroup[] = [];
+    filterSearch: FilterSearchActive<TData> | null = null;
+    allFilterValues: FilterGroup[] = [];
+    valueFormatters: ValueFormatterFilter<TData>[] = [];
+
+    /**
+     * Callbacks
+     */
+    onFilteredDataChangedCallbacks: Callback<OnFilterDataChangeCallback<TData>>[] = [];
+    onFilterStateChangedCallbacks: Callback<OnFilterStateChangedCallback<TData>>[] = [];
+
+    /**
+     * Register callback to be called when filter state changes
+     */
+    onFilterStateChange = (cb: OnFilterStateChangedCallback<TData>): OnCallbackSet =>
+        registerCallback(cb, this.onFilterStateChangedCallbacks, this.unsubOnFilterStateChange);
+
+    private unsubOnFilterStateChange = (id: string) => {
+        this.onFilterStateChangedCallbacks = this.onFilterStateChangedCallbacks.filter(
+            (s) => s.id !== id
+        );
+    };
+
+    /**
+     * Register callback to be called when filtered data changes
+     */
+    onFilterDataChange = (cb: OnFilterDataChangeCallback<TData>): OnCallbackSet =>
+        registerCallback(cb, this.onFilteredDataChangedCallbacks, this.unsubOnFilterDataChange);
+
+    private unsubOnFilterDataChange = (id: string) => {
+        this.onFilteredDataChangedCallbacks = this.onFilteredDataChangedCallbacks.filter(
+            (s) => s.id !== id
+        );
+    };
+
+    private notifyFilterDataChange = () => {
+        this.onFilteredDataChangedCallbacks.forEach(({ callback }) =>
+            callback(this.filteredData, this)
+        );
+    };
+
+    addValueFormatters = (valueFormatters: ValueFormatterFilter<TData>[]) => {
+        this.valueFormatters = [...this.valueFormatters, ...valueFormatters];
+    };
+
+    checkValueIsInactive = (groupName: string, value: FilterValueType) =>
+        Boolean(this.filterState.find(({ name }) => name === groupName)?.values.includes(value));
+
+    getGroupValues = (groupName: string) =>
+        this.allFilterValues.find(({ name }) => name === groupName)?.values ?? [];
+
+    getInactiveGroupValues = (groupName: string) =>
+        this.filterState.find(({ name }) => name === groupName)?.values ?? [];
+
+    /**
+     * Gets count for all the filter values in a filter group
+     * @param groupName
+     * @returns
+     */
+    getFilterItemCountsForGroup = (groupName: string): FilterItemCount[] => {
+        const filterGroup = this.allFilterValues.find(({ name }) => name === groupName);
+        if (!filterGroup) return [];
+
+        return filterGroup.values.map(
+            (value): FilterItemCount => ({
+                name: value,
+                count: this.getCountForFilterValue(filterGroup, value),
+            })
+        );
+    };
+
+    getCountForFilterValue = (
+        filterGroup: FilterGroup,
+        filterItem: FilterValueType,
+        valueFormatterFunc?: ValueFormatterFunction<unknown>
+    ) => {
+        const valueFormatter =
+            valueFormatterFunc ??
+            this.valueFormatters.find(({ name }) => name === filterGroup.name)?.valueFormatter;
+        if (!valueFormatter) return -1;
+
+        const uncheckedValues = filterGroup.values.filter((value) => value !== filterItem);
+
+        return this.filteredData.reduce((count, val) => {
+            return doesItemPassCriteria(uncheckedValues, valueFormatter(val)) ? count + 1 : count;
+        }, 0);
+    };
+
+    /**
+     * @internal
+     */
+    filter = () => {
+        if (!this.data || this.data.length === 0) return;
+        this.setFilteredData(
+            this.data.filter((item) =>
+                doesItemPassFilter(item, this.filterState, this.valueFormatters)
+            )
+        );
+        if (this.filterSearch !== null) {
+            this.handleSearch();
+        }
+    };
+
+    createFilterValues = () => {
+        this.allFilterValues = generateFilterValues(this.valueFormatters, this.data);
+    };
+
+    /** Add or remove a filter value from the blacklist */
+    changeFilterItem = (
+        action: 'MarkInactive' | 'MarkActive',
+        groupName: string,
+        newValue: FilterValueType,
+        preventFiltering?: boolean
+    ) => {
+        if (filterGroupExists(groupName, this.filterState)) {
+            /**
+             * Group exists add or remove
+             */
+            const group = this.filterState.find(({ name }) => name === groupName);
+            if (!group) return;
+            group.values =
+                action === 'MarkInactive'
+                    ? [...group.values, newValue]
+                    : [...group.values.filter((value) => value !== newValue)];
+        } else {
+            if (action === 'MarkActive') return;
+            /** only add */
+            this.filterState.push({ name: groupName, values: [newValue] });
+        }
+        /** Actually do the filtering */
+        !preventFiltering && this.filter();
+        this.onFilterStateChangedCallbacks.forEach(({ callback }) =>
+            callback(this.filterState, this)
+        );
+    };
+
+    /**
+     * Add or remove all values in a filter group
+     */
+    markAllValuesActive = (groupName: string) => {
+        const group = this.filterState.find(({ name }) => name === groupName);
+        if (!group) return;
+        this.setFilterState(this.filterState.filter(({ name }) => name !== groupName));
+        this.filter();
+    };
+
+    /**
+     * Manually set the filter state
+     */
+    setFilterState = (newFilterState: FilterGroup[]) => {
+        this.filterState = newFilterState;
+        this.onFilterStateChangedCallbacks.forEach(({ callback }) =>
+            callback(newFilterState, this)
+        );
+    };
+
+    /**
+     * Destroys the filter
+     */
+    destroyFilter = () => {
+        this.setFilteredData(this.data);
+        this.setFilterState([]);
+        this.setAllFilterValues([]);
+    };
+
+    /** Clears all active filters */
+    clearActiveFilters = () => {
+        this.setFilterState([]);
+    };
+
+    /**
+     * @internal
+     * Set filter values
+     * @param newFilterValues
+     */
+    setAllFilterValues = (newFilterValues: FilterGroup[]) => {
+        this.allFilterValues = newFilterValues;
+    };
+
+    /**
+     * @internal
+     * Set filter data
+     */
+    setFilteredData = (newData: TData[]) => {
+        this.filteredData = newData;
+        this.notifyFilterDataChange();
+    };
+    /**
+     * @internal
+     * Set filter data
+     */
+    setData = (newData: TData[]) => {
+        this.data = newData;
+    };
+
+    /** Clears the search and filters the data using the current filterstate */
+    clearSearch = (): void => {
+        this.filterSearch = null;
+        this.filter();
+    };
+
+    handleSearch = () => {
+        if (this.filterSearch === null) return;
+        const { searchIn, searchValue, type, valueFormatters } = this.filterSearch;
+        const haystack = searchIn === 'Data' ? this.data : this.filteredData;
+        const needle = searchValue.toLowerCase();
+
+        const results =
+            type === 'includes'
+                ? searchForIncludes(valueFormatters, haystack, needle)
+                : searchForStartsWith(valueFormatters, haystack, needle);
+
+        this.setFilteredData(results);
+    };
+
+    /** Search across multiple filter groups for a value that matches at least one */
+    search = (searchArgs: FilterSearchActive<TData>): void => {
+        if (searchArgs.valueFormatters.length === 0) return;
+        this.filterSearch = searchArgs;
+    };
+}

--- a/packages/filter/src/lib/classes/index.ts
+++ b/packages/filter/src/lib/classes/index.ts
@@ -1,0 +1,1 @@
+export * from './FilterController';

--- a/packages/filter/src/lib/components/ClickableIcon.tsx
+++ b/packages/filter/src/lib/components/ClickableIcon.tsx
@@ -1,0 +1,32 @@
+import { Icon } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+
+export interface ClickableIconProps {
+    name: string;
+    onClick?: React.MouseEventHandler<SVGSVGElement>;
+    color?: string | undefined;
+    size?: 16 | 24 | 32 | 40 | 48;
+}
+
+/**
+ * TODO: Make union type of available EDS icons
+ * Expand with props as needed
+ * Wraps EDS icon and styles it so its clickable
+ * @returns Clickable SVG
+ */
+export const ClickableIcon = ({
+    name,
+    onClick,
+    color = `${tokens.colors.interactive.primary__resting.hex}`,
+    size = 24,
+}: ClickableIconProps): JSX.Element => {
+    return (
+        <Icon
+            size={size}
+            name={name}
+            onClick={onClick}
+            style={{ cursor: 'pointer' }}
+            color={color}
+        />
+    );
+};

--- a/packages/filter/src/lib/components/ExpandedFilterGroup/ExpandedFilterGroup.tsx
+++ b/packages/filter/src/lib/components/ExpandedFilterGroup/ExpandedFilterGroup.tsx
@@ -1,0 +1,174 @@
+import { Icon, Search } from '@equinor/eds-core-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useVirtual } from 'react-virtual';
+import { useFilterController } from '../../hooks/useFilterContext';
+import { FilterClearIcon } from '../../icons';
+import { FilterConfiguration, FilterGroup } from '../../types';
+import { convertFromBlank, DEFAULT_NULL_VALUE } from '../../utils/convertFromBlank';
+import { searchByValue } from '../../utils/searchByvalue';
+import { Case, Switch } from '../../utils/Switch';
+import {
+    SearchButton,
+    StyledFilterHeaderGroup,
+    Title,
+    VirtualFilterContainer,
+    VirtualFilterItemWrapper,
+    Wrapper,
+} from './expandedFilterGroup.styles';
+import { FilterItemValue } from './FilterItem';
+
+interface FilterGroupeComponentProps {
+    filterGroup: FilterGroup;
+    hideTitle?: boolean;
+}
+
+export const ExpandedFilterGroup = ({ filterGroup }: FilterGroupeComponentProps) => {
+    const { getInactiveGroupValues, filterState, markAllValuesActive, setFilterState } =
+        useFilterController();
+
+    const [filterSearchValue, setFilterSearchValue] = useState('');
+    const [searchActive, setSearchActive] = useState(false);
+
+    function handleOnChange(event: React.ChangeEvent<HTMLInputElement>) {
+        const value = event.target.value;
+        setFilterSearchValue(value);
+    }
+
+    function handleSearchButtonClick() {
+        setSearchActive((isActive) => !isActive);
+    }
+
+    const isSearchable = filterGroup.values.length > 10;
+    const hasAnyActiveFilters = Boolean(getInactiveGroupValues(filterGroup.name).length);
+
+    const groupsMatchingSearch = useMemo(
+        () =>
+            searchByValue(
+                filterGroup.values.map((v) => (v !== null ? v.toString() : DEFAULT_NULL_VALUE)),
+                filterSearchValue
+            ),
+        [filterGroup.values, filterSearchValue]
+    );
+
+    return (
+        <Wrapper>
+            <StyledFilterHeaderGroup isActive={hasAnyActiveFilters}>
+                <Switch>
+                    <Case when={searchActive}>
+                        <Search
+                            autoFocus={searchActive}
+                            onBlur={() => {
+                                setSearchActive(false);
+                                setFilterSearchValue('');
+                            }}
+                            aria-label="in filter group"
+                            id="search-normal"
+                            placeholder="Search"
+                            onChange={handleOnChange}
+                            onKeyPress={(e) => {
+                                if (e.key === 'Enter') {
+                                    setFilterState([
+                                        ...filterState.filter((s) => s.name !== filterGroup.name),
+                                        {
+                                            name: filterGroup.name,
+                                            values: filterGroup.values.filter(
+                                                (s) =>
+                                                    !groupsMatchingSearch.includes(
+                                                        s?.toString() ?? '(Blank)'
+                                                    )
+                                            ),
+                                        },
+                                    ]);
+                                    setFilterSearchValue('');
+                                    setSearchActive(false);
+                                }
+                            }}
+                        />
+                    </Case>
+                    <Case when={true}>
+                        <Title
+                            onClick={() => isSearchable && handleSearchButtonClick()}
+                            hasFilters={hasAnyActiveFilters}
+                        >
+                            {filterGroup.name}
+                        </Title>
+                        {isSearchable && (
+                            <SearchButton variant="ghost_icon" onClick={handleSearchButtonClick}>
+                                <Icon name={'search'} id={'search'} />
+                            </SearchButton>
+                        )}
+                        {hasAnyActiveFilters && (
+                            <FilterClearIcon
+                                onClick={() => markAllValuesActive(filterGroup.name)}
+                            />
+                        )}
+                    </Case>
+                </Switch>
+            </StyledFilterHeaderGroup>
+            <VirtualContainer filterGroup={filterGroup} filterSearchValue={filterSearchValue} />
+        </Wrapper>
+    );
+};
+
+interface VirtualContainerProps {
+    filterGroup: FilterGroup;
+    filterSearchValue: string;
+}
+
+export const VirtualContainer = ({
+    filterGroup,
+    filterSearchValue,
+}: VirtualContainerProps): JSX.Element | null => {
+    const { valueFormatters } = useFilterController();
+    const filterOptions: FilterConfiguration<unknown>[] = [];
+
+    const groupsMatchingSearch = useMemo(
+        () =>
+            searchByValue(
+                filterGroup.values.map((v) => (v !== null ? v.toString() : DEFAULT_NULL_VALUE)),
+                filterSearchValue
+            ),
+        [filterGroup.values, filterSearchValue]
+    );
+
+    const rowLength = useMemo(() => groupsMatchingSearch.length, [groupsMatchingSearch]);
+
+    const parentRef = useRef<HTMLDivElement | null>(null);
+
+    const valueFormatter = valueFormatters.find(
+        ({ name }) => name === filterGroup.name
+    )?.valueFormatter;
+
+    const rowVirtualizer = useVirtual({
+        parentRef,
+        size: rowLength,
+        estimateSize: useCallback(() => 20, []),
+    });
+    if (!valueFormatter) return null;
+    return (
+        <VirtualFilterContainer ref={parentRef}>
+            <VirtualFilterItemWrapper
+                style={{
+                    height: `${rowVirtualizer.totalSize}px`,
+                }}
+            >
+                {rowVirtualizer.virtualItems.map((virtualRow) => {
+                    return (
+                        <FilterItemValue
+                            valueFormatter={valueFormatter}
+                            key={convertFromBlank(groupsMatchingSearch[virtualRow.index])}
+                            virtualRowSize={virtualRow.size}
+                            virtualRowStart={virtualRow.start}
+                            filterItem={convertFromBlank(groupsMatchingSearch[virtualRow.index])}
+                            filterGroup={filterGroup}
+                            CustomRender={
+                                filterOptions?.find(({ name }) => name === filterGroup.name)
+                                    ?.customValueRender
+                            }
+                        />
+                    );
+                })}
+            </VirtualFilterItemWrapper>
+        </VirtualFilterContainer>
+    );
+};

--- a/packages/filter/src/lib/components/ExpandedFilterGroup/FilterItem.tsx
+++ b/packages/filter/src/lib/components/ExpandedFilterGroup/FilterItem.tsx
@@ -1,0 +1,71 @@
+import { Checkbox } from '@equinor/eds-core-react';
+import { memo, useMemo } from 'react';
+import { useFilterController } from '../../hooks/useFilterContext';
+import { FilterGroup, FilterValueType, ValueFormatterFunction } from '../../types';
+import { DEFAULT_NULL_VALUE } from '../../utils/convertFromBlank';
+import { Count, FilterItemName, FilterItemWrap } from '../filterItem/filterItem.styles';
+
+const sanitizeFilterItemName = (value: FilterValueType) => value?.toString() ?? DEFAULT_NULL_VALUE;
+
+type FilterItemValueProps = {
+    virtualRowStart: number;
+    virtualRowSize: number;
+    filterItem: FilterValueType;
+    filterGroup: FilterGroup;
+    valueFormatter: ValueFormatterFunction<unknown>;
+    CustomRender?: (value: FilterValueType) => JSX.Element;
+};
+
+export const FilterItem = ({
+    virtualRowStart,
+    virtualRowSize,
+    filterItem,
+    filterGroup,
+    valueFormatter,
+    CustomRender = (value) => <>{sanitizeFilterItemName(value)}</>,
+}: FilterItemValueProps): JSX.Element => {
+    const { getGroupValues, changeFilterItem, checkValueIsInactive, getCountForFilterValue } =
+        useFilterController();
+    function uncheckAllButThisValue() {
+        getGroupValues(filterGroup.name).forEach((value) =>
+            changeFilterItem('MarkInactive', filterGroup.name, value, true)
+        );
+
+        changeFilterItem('MarkActive', filterGroup.name, filterItem);
+    }
+    const isUnChecked = checkValueIsInactive(filterGroup.name, filterItem);
+    const count = useMemo(
+        () => getCountForFilterValue(filterGroup, filterItem, valueFormatter),
+        [getCountForFilterValue, filterGroup.name, filterItem]
+    );
+    return (
+        <FilterItemWrap
+            title={typeof filterItem === 'string' ? filterItem : '(Blank)'}
+            style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRowStart}px)`,
+                height: `${virtualRowSize}px`,
+            }}
+        >
+            <Checkbox
+                checked={!isUnChecked}
+                onChange={() =>
+                    changeFilterItem(
+                        isUnChecked ? 'MarkActive' : 'MarkInactive',
+                        filterGroup.name,
+                        filterItem
+                    )
+                }
+            />
+            <FilterItemName onClick={uncheckAllButThisValue}>
+                {CustomRender(filterItem)}
+            </FilterItemName>
+            {!isUnChecked && <Count>({count})</Count>}
+        </FilterItemWrap>
+    );
+};
+
+export const FilterItemValue = memo(FilterItem);

--- a/packages/filter/src/lib/components/ExpandedFilterGroup/expandedFilterGroup.styles.ts
+++ b/packages/filter/src/lib/components/ExpandedFilterGroup/expandedFilterGroup.styles.ts
@@ -1,0 +1,114 @@
+import { Button, Checkbox } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import styled from 'styled-components';
+
+export const Title = styled.h4<{ hasFilters: boolean }>`
+    margin: 0.2rem;
+    white-space: nowrap;
+    font-size: 14px;
+    font-weight: ${({ hasFilters }) => (hasFilters ? '700' : '400')};
+`;
+
+export const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin: 0rem 0.5rem 0rem 1rem;
+    width: fit-content;
+    max-width: 500px;
+    text-overflow: ellipsis;
+    word-wrap: break-word;
+    height: 180px;
+
+    #search {
+        visibility: hidden;
+    }
+
+    &:hover #search {
+        visibility: visible;
+    }
+
+    label {
+        padding: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        span {
+            padding: 0rem;
+        }
+        svg {
+            height: 18px;
+            width: 18px;
+        }
+    }
+`;
+export const VirtualFilterContainer = styled.div`
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+    ::-webkit-scrollbar {
+        height: 0.1rem;
+        width: 0.3rem;
+    }
+`;
+
+export const VirtualFilterItemWrapper = styled.div`
+    width: auto;
+    min-width: 150px;
+    position: relative;
+`;
+export const FilterGroupWrapper = styled.div`
+    overflow-x: hidden;
+    overflow-y: scroll;
+
+    ::-webkit-scrollbar {
+        height: 0.1rem;
+        width: 0.3rem;
+    }
+`;
+export const FilterItemWrapper = styled.div`
+    padding-bottom: 1rem;
+`;
+
+export const StyledFilterHeaderGroup = styled.div<{ isActive: boolean }>`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    height: 50px;
+    min-height: 50px;
+    box-sizing: border-box;
+    border-bottom: ${({ isActive }) =>
+        `2px solid ${
+            isActive
+                ? tokens.colors.interactive.primary__resting.hex
+                : tokens.colors.ui.background__medium.hex
+        }`};
+
+    color: ${({ isActive }) =>
+        isActive
+            ? tokens.colors.interactive.primary__resting.hex
+            : tokens.colors.text.static_icons__default.hex};
+
+    margin-bottom: 5px;
+`;
+
+export const SearchButton = styled(Button)`
+    width: 36px;
+    height: 36px;
+`;
+
+export const AllCheckbox = styled(Checkbox)`
+    grid-template-columns: auto 1fr auto;
+    display: grid;
+    max-width: 500px;
+    align-items: center;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    span {
+        font-size: 13px;
+        padding: 0px;
+
+        :first-child {
+            padding-right: 2px;
+        }
+    }
+`;

--- a/packages/filter/src/lib/components/SearchPickerDropdown.tsx
+++ b/packages/filter/src/lib/components/SearchPickerDropdown.tsx
@@ -1,0 +1,45 @@
+import { Menu } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import { useRef, useState } from 'react';
+import { ClickableIcon } from './ClickableIcon';
+
+interface MenuItem {
+    title: string;
+    onCLick: () => void;
+}
+interface SearchPickerDropdownProps {
+    menuItems: MenuItem[];
+}
+
+export function SearchPickerDropdown({ menuItems }: SearchPickerDropdownProps): JSX.Element {
+    const ref = useRef<HTMLDivElement>(null);
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+        <>
+            <div ref={ref}>
+                <ClickableIcon
+                    name="chevron_down"
+                    onClick={() => setIsOpen(true)}
+                    color={tokens.colors.interactive.primary__resting.hex}
+                />
+            </div>
+            {isOpen && (
+                <Menu
+                    id="menu-complex"
+                    aria-labelledby="anchor-complex"
+                    open={true}
+                    anchorEl={ref.current}
+                    onClose={() => setIsOpen(false)}
+                    placement={'bottom-end'}
+                    title="Search for.."
+                >
+                    {menuItems.map((s) => (
+                        <Menu.Item key={s.title} onClick={s.onCLick}>
+                            {s.title}
+                        </Menu.Item>
+                    ))}
+                </Menu>
+            )}
+        </>
+    );
+}

--- a/packages/filter/src/lib/components/ToggleHideFilterPopover.tsx
+++ b/packages/filter/src/lib/components/ToggleHideFilterPopover.tsx
@@ -1,0 +1,110 @@
+import { Button, Icon, Checkbox, Popover } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import { useState, useRef } from 'react';
+import { ReactSortable } from 'react-sortablejs';
+import styled from 'styled-components';
+
+interface ShowHideFilterButtonProps {
+    allFilters: string[];
+    visibleFilters: string[];
+    setVisibleFilters: (val: string[]) => void;
+}
+
+interface SortObject<T> {
+    id: string;
+    item: T;
+}
+export const ToggleHideFilterPopover = ({
+    setVisibleFilters,
+    visibleFilters,
+    allFilters,
+}: ShowHideFilterButtonProps): JSX.Element => {
+    const [isOpen, setIsOpen] = useState(false);
+    const ref = useRef<HTMLDivElement>(null);
+
+    const [list, setList] = useState<SortObject<string>[]>(
+        allFilters.map((s) => ({ id: s, item: s }))
+    );
+
+    const handleChange = (val: string) => {
+        if (visibleFilters.includes(val)) {
+            setVisibleFilters(visibleFilters.filter((s) => s !== val));
+        } else {
+            setVisibleFilters([...visibleFilters, val]);
+        }
+    };
+    const DraggableHandleSelector = 'globalDraggableHandle';
+
+    const updateList = () =>
+        setVisibleFilters(list.map((s) => s.item).filter((s) => visibleFilters.includes(s)));
+
+    return (
+        <>
+            <div ref={ref}>
+                <Button title="Add filters" variant="ghost_icon" onClick={() => setIsOpen(true)}>
+                    <Icon
+                        name="playlist_add"
+                        color={tokens.colors.interactive.primary__resting.hex}
+                    />
+                </Button>
+            </div>
+
+            {isOpen && (
+                <Popover
+                    open={isOpen}
+                    onClose={() => setIsOpen(false)}
+                    anchorEl={ref.current}
+                    placement="bottom-end"
+                >
+                    <Popover.Title>Filter types</Popover.Title>
+                    <Popover.Content
+                        style={{ maxHeight: '60vh', overflowY: 'scroll', overflowX: 'hidden' }}
+                    >
+                        <PopoverList>
+                            <ReactSortable
+                                animation={200}
+                                handle={`.${DraggableHandleSelector}`}
+                                list={list}
+                                setList={setList}
+                                onEnd={updateList}
+                            >
+                                {list.map(({ item }) => (
+                                    <ItemWrapper className={DraggableHandleSelector} key={item}>
+                                        <Checkbox
+                                            size={2}
+                                            checked={visibleFilters.includes(item)}
+                                            onChange={() => {
+                                                handleChange(item);
+                                            }}
+                                        />
+                                        <div>{item}</div>
+                                        <Icon
+                                            name="drag_handle"
+                                            color={tokens.colors.interactive.primary__resting.hex}
+                                        />
+                                    </ItemWrapper>
+                                ))}
+                            </ReactSortable>
+                        </PopoverList>
+                    </Popover.Content>
+                </Popover>
+            )}
+        </>
+    );
+};
+
+const PopoverList = styled.div`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-bottom: 20px;
+`;
+
+const ItemWrapper = styled.div`
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+
+    align-items: center;
+    width: 100%;
+    height: 32px;
+`;

--- a/packages/filter/src/lib/components/filterGroup/FilterGroup.tsx
+++ b/packages/filter/src/lib/components/filterGroup/FilterGroup.tsx
@@ -1,0 +1,87 @@
+import { Icon } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import { useRef } from 'react';
+import { useFilterController } from '../../hooks/useFilterContext';
+import { FilterConfiguration, FilterValueType } from '../../types';
+import { FilterGroupWrapper, NormalText } from './filterGroup.styles';
+import { FilterGroupPopoverMenu } from './FilterGroupPopoverMenu';
+
+interface FilterGroupProps {
+    name: string;
+    isOpen: boolean;
+    onClick: () => void;
+}
+export const FilterGroup = <T,>({ name, isOpen, onClick }: FilterGroupProps): JSX.Element => {
+    const ref = useRef<HTMLDivElement>(null);
+    const filterOptions: FilterConfiguration<T>[] = [];
+
+    const {
+        setFilterState,
+        getGroupValues,
+        checkValueIsInactive,
+        getInactiveGroupValues,
+        changeFilterItem,
+        markAllValuesActive,
+        filterState,
+    } = useFilterController();
+
+    const handleFilterItemLabelClick = (val: FilterValueType) =>
+        setFilterState([
+            ...filterState.filter((s) => s.name !== name),
+            { name: name, values: getGroupValues(name).filter((s) => s !== val) },
+        ]);
+
+    const values = getGroupValues(name);
+
+    const isChecked = (filterValue: FilterValueType) => checkValueIsInactive(name, filterValue);
+
+    const handleFilterItemClick = (filterItem: FilterValueType) =>
+        changeFilterItem(isChecked(filterItem) ? 'MarkActive' : 'MarkInactive', name, filterItem);
+
+    const isAllChecked = getInactiveGroupValues(name).length === 0;
+
+    const checkedValues = values.filter((value) => !getInactiveGroupValues(name).includes(value));
+
+    const customRender =
+        filterOptions.find((s) => s.name === name)?.customValueRender ??
+        ((v) => <>{v?.toString() ?? '(Blank)'}</>);
+
+    if (values.length === 0) return <></>;
+    return (
+        <div>
+            <FilterGroupWrapper ref={ref} onClick={onClick}>
+                <div>{getFilterHeaderText(isAllChecked, name, checkedValues)}</div>
+                <Icon color={tokens.colors.text.static_icons__tertiary.hex} name="chevron_down" />
+            </FilterGroupWrapper>
+            {isOpen && (
+                <FilterGroupPopoverMenu
+                    handleFilterItemLabelClick={handleFilterItemLabelClick}
+                    handleFilterItemClick={handleFilterItemClick}
+                    isChecked={isChecked}
+                    markAllValuesActive={() => markAllValuesActive(name)}
+                    onClick={onClick}
+                    anchorEl={ref.current}
+                    values={values}
+                    CustomRender={customRender}
+                    groupName={name}
+                />
+            )}
+        </div>
+    );
+};
+
+export function getFilterHeaderText(
+    isAllChecked: boolean,
+    name: string,
+    checkedValues: FilterValueType[]
+): string | JSX.Element {
+    if (isAllChecked || checkedValues.length === 0) return <NormalText>{name}</NormalText>;
+
+    return (
+        <div style={{ color: tokens.colors.interactive.primary__resting.hex }}>
+            {checkedValues.length - 1 > 0
+                ? `${checkedValues[0] ?? '(Blank)'}(+${checkedValues.length - 1})`
+                : `${checkedValues[0]}`}{' '}
+        </div>
+    );
+}

--- a/packages/filter/src/lib/components/filterGroup/FilterGroupPopoverMenu.tsx
+++ b/packages/filter/src/lib/components/filterGroup/FilterGroupPopoverMenu.tsx
@@ -1,0 +1,119 @@
+import { Menu, Button, Search } from '@equinor/eds-core-react';
+import { useState } from 'react';
+import styled from 'styled-components';
+import { useFilterController } from '../../hooks/useFilterContext';
+import { FilterValueType } from '../../types';
+import { FilterItemCheckbox } from '../filterItem/FilterItemCheckbox';
+import { ClearButtonWrapper, MenuWrapper, SearchHolder, VerticalLine } from './filterGroup.styles';
+
+interface FilterGroupPopoverMenuProps {
+    anchorEl: HTMLElement | null | undefined;
+    onClick: () => void;
+    values: FilterValueType[];
+    handleFilterItemClick: (item: FilterValueType) => void;
+    isChecked: (filterValue: FilterValueType) => boolean;
+    markAllValuesActive: () => void;
+    CustomRender: (value: FilterValueType) => JSX.Element;
+    handleFilterItemLabelClick: (val: FilterValueType) => void;
+    groupName: string;
+}
+export const FilterGroupPopoverMenu = ({
+    handleFilterItemClick,
+    isChecked,
+    handleFilterItemLabelClick,
+    markAllValuesActive,
+    onClick,
+    anchorEl,
+    values,
+    CustomRender,
+    groupName,
+}: FilterGroupPopoverMenuProps): JSX.Element => {
+    const [searchText, setSearchText] = useState<string>('');
+
+    const { valueFormatters, setFilterState, filterState, getCountForFilterValue } =
+        useFilterController();
+    const valueFormatter = valueFormatters.find(({ name }) => name === groupName)?.valueFormatter;
+
+    const handleInput = (e) => setSearchText(e.target.value.toString().toLowerCase());
+
+    const getValuesMatchingSearchText = () =>
+        values.filter((s) => !searchText || s?.toString().toLowerCase().startsWith(searchText));
+
+    const setFilterStateFromSearch = () => {
+        const valuesMatchingSearch = values.filter(
+            (s) => !getValuesMatchingSearchText().includes(s)
+        );
+
+        setFilterState([
+            ...filterState.filter((s) => s.name !== groupName),
+            {
+                name: groupName,
+                values: valuesMatchingSearch,
+            },
+        ]);
+        setSearchText('');
+        onClick();
+    };
+
+    return (
+        <Menu
+            id="menu-complex"
+            aria-labelledby="anchor-complex"
+            open={true}
+            anchorEl={anchorEl}
+            onClose={onClick}
+            placement={'bottom-end'}
+        >
+            <MenuWrapper>
+                {values.length > 7 && (
+                    <>
+                        <SearchHolder>
+                            <Search
+                                value={searchText}
+                                placeholder="Search"
+                                onInput={handleInput}
+                                onKeyPress={(e) => {
+                                    if (e.key === 'Enter') {
+                                        setFilterStateFromSearch();
+                                    }
+                                }}
+                            />
+                        </SearchHolder>
+                        <VerticalLine />
+                    </>
+                )}
+
+                <List>
+                    {getValuesMatchingSearchText().map((value) => (
+                        <FilterItemCheckbox
+                            key={value}
+                            ValueRender={() => CustomRender(value)}
+                            filterValue={value}
+                            handleFilterItemClick={() => handleFilterItemClick(value)}
+                            handleFilterItemLabelClick={() => handleFilterItemLabelClick(value)}
+                            isChecked={isChecked(value)}
+                            count={getCountForFilterValue(
+                                { name: groupName, values },
+                                value,
+                                valueFormatter
+                            )}
+                        />
+                    ))}
+                </List>
+                <VerticalLine />
+                <ClearButtonWrapper>
+                    <Button onClick={markAllValuesActive} variant="ghost">
+                        Clear
+                    </Button>
+                </ClearButtonWrapper>
+            </MenuWrapper>
+        </Menu>
+    );
+};
+
+const List = styled.div`
+    max-height: 250px;
+    padding: 8px 8px;
+    overflow: scroll;
+    height: auto;
+`;

--- a/packages/filter/src/lib/components/filterGroup/filterGroup.styles.ts
+++ b/packages/filter/src/lib/components/filterGroup/filterGroup.styles.ts
@@ -1,0 +1,57 @@
+import { tokens } from '@equinor/eds-tokens';
+import styled from 'styled-components';
+
+export const FilterGroupWrapper = styled.div`
+    height: auto;
+    width: auto;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding-left: 2px;
+    font-size: 14px;
+    font-weight: 700;
+    line-height: 20px;
+    text-align: left;
+    border-radius: 5px;
+    &:hover {
+        background-color: ${tokens.colors.interactive.primary__hover_alt.hex};
+    }
+`;
+
+export const NormalText = styled.div`
+    font-weight: 400;
+`;
+
+export const VerticalLine = styled.div`
+    width: 100%;
+    height: 2px;
+    background-color: ${tokens.colors.ui.background__medium.hex};
+`;
+
+export const SearchHolder = styled.div`
+    padding-right: 0.5em;
+    padding-left: 0.5em;
+    padding-top: 0.8em;
+    padding-bottom: calc(8px + 0.8em);
+`;
+
+export const MenuWrapper = styled.div`
+    width: 200px;
+`;
+
+export const FilterItemList = styled.div<{ items: number }>`
+    height: ${({ items }) => (items > 10 ? '300px' : `${items * 22 + 16}px`)};
+    padding: 8px 8px;
+`;
+
+export const ClearButtonWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding-top: 8px;
+    padding-right: 5px;
+`;

--- a/packages/filter/src/lib/components/filterGroup/index.ts
+++ b/packages/filter/src/lib/components/filterGroup/index.ts
@@ -1,0 +1,2 @@
+export { FilterGroup } from './FilterGroup';
+export { FilterGroupPopoverMenu } from './FilterGroupPopoverMenu';

--- a/packages/filter/src/lib/components/filterItem/FilterItemCheckbox.tsx
+++ b/packages/filter/src/lib/components/filterItem/FilterItemCheckbox.tsx
@@ -1,0 +1,103 @@
+import { Checkbox } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import { VirtualItem } from 'react-virtual';
+import styled from 'styled-components';
+import { FilterValueType } from '../../types';
+import { Count } from './filterItem.styles';
+
+interface FilterItemCheckboxProps {
+    filterValue: FilterValueType;
+    handleFilterItemClick: () => void;
+    handleFilterItemLabelClick: () => void;
+    isChecked: boolean;
+    ValueRender: () => JSX.Element;
+    count?: number;
+}
+
+interface VirtualFilterItemCheckboxProps extends FilterItemCheckboxProps {
+    virtualItem: VirtualItem;
+}
+
+export const VirtualFilterItemCheckbox = ({
+    count,
+    filterValue,
+    handleFilterItemClick,
+    isChecked,
+    handleFilterItemLabelClick,
+    ValueRender,
+    virtualItem,
+}: VirtualFilterItemCheckboxProps): JSX.Element => {
+    return (
+        <FilterItemWrap
+            title={typeof filterValue === 'string' ? filterValue : '(Blank)'}
+            style={{
+                transform: `translateY(${virtualItem.start}px)`,
+                height: `${virtualItem.size}px`,
+                position: 'absolute',
+                top: 0,
+                left: 0,
+            }}
+            key={filterValue}
+        >
+            <Checkbox onChange={handleFilterItemClick} size={12} checked={!isChecked} />
+            <FilterLabelWrapper onClick={handleFilterItemLabelClick}>
+                <ValueRender />
+            </FilterLabelWrapper>
+            {typeof count === 'number' && <Count>({count})</Count>}
+        </FilterItemWrap>
+    );
+};
+
+const FilterLabelWrapper = styled.div`
+    cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`;
+
+export const FilterItemWrap = styled.div`
+    grid-template-columns: auto 1fr auto;
+    display: grid;
+    align-items: center;
+    padding-top: 2px;
+
+    width: 100%;
+    padding-bottom: 2px;
+    > span {
+        padding: 0px;
+
+        > svg {
+            width: 18px;
+            height: 18px;
+        }
+
+        :first-child {
+            padding-right: 2px;
+        }
+    }
+    :hover {
+        background-color: ${tokens.colors.interactive.primary__selected_hover.rgba};
+    }
+`;
+
+export const FilterItemCheckbox = ({
+    count,
+    filterValue,
+    handleFilterItemClick,
+    isChecked,
+    handleFilterItemLabelClick,
+    ValueRender,
+}: FilterItemCheckboxProps): JSX.Element => {
+    return (
+        <FilterItemWrap
+            title={typeof filterValue === 'string' ? filterValue : '(Blank)'}
+            key={filterValue}
+        >
+            <Checkbox onChange={handleFilterItemClick} size={12} checked={!isChecked} />
+            <FilterLabelWrapper onClick={handleFilterItemLabelClick}>
+                <ValueRender />
+            </FilterLabelWrapper>
+            {typeof count === 'number' && <Count>({count})</Count>}
+        </FilterItemWrap>
+    );
+};

--- a/packages/filter/src/lib/components/filterItem/filterItem.styles.ts
+++ b/packages/filter/src/lib/components/filterItem/filterItem.styles.ts
@@ -1,0 +1,45 @@
+import { Checkbox } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import styled from 'styled-components';
+
+export const AllCheckbox = styled(Checkbox)`
+    padding-left: 0.5rem !important;
+`;
+
+export const FilterItemName = styled.span`
+    cursor: pointer;
+    font-size: 13px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+`;
+
+export const Count = styled.span`
+    font-size: 10px;
+    margin-left: 0.5em;
+    margin-right: 0.5em;
+`;
+
+export const FilterItemWrap = styled.div`
+    grid-template-columns: auto 1fr auto;
+    display: grid;
+    max-width: 500px;
+    align-items: center;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    > span {
+        padding: 0px;
+
+        > svg {
+            width: 18px;
+            height: 18px;
+        }
+
+        :first-child {
+            padding-right: 2px;
+        }
+    }
+    :hover {
+        background-color: ${tokens.colors.interactive.primary__selected_hover.rgba};
+    }
+`;

--- a/packages/filter/src/lib/components/filterQuickSearch/FilterQuickSearch.tsx
+++ b/packages/filter/src/lib/components/filterQuickSearch/FilterQuickSearch.tsx
@@ -1,0 +1,72 @@
+import { Search } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import { useState } from 'react';
+import styled from 'styled-components';
+import { getPlaceholderText } from '../../functions/getPlaceholderText';
+import { useFilterController } from '../../hooks/useFilterContext';
+import { SearchPickerDropdown } from '../SearchPickerDropdown';
+
+export type SearchMode = 'id/desc' | 'all';
+
+export const FilterQuickSearch = (): JSX.Element => {
+    const [searchText, setSearchText] = useState<string | undefined>();
+
+    const { search, clearSearch, valueFormatters } = useFilterController();
+
+    const searchOptions = [];
+
+    const [searchMode, setSearchMode] = useState<SearchMode>('id/desc');
+
+    function handleClear(e) {
+        if (!e.isTrusted) {
+            setSearchText(undefined);
+            clearSearch();
+        }
+    }
+    function handleInput(e) {
+        const value = e.target.value;
+        if (!value) clearSearch();
+        setSearchText(value);
+    }
+    function doSearch(value: string) {
+        if (value === '') {
+            clearSearch();
+        } else {
+            search({
+                searchValue: value,
+                searchIn: 'FilteredData',
+                type: 'includes',
+                valueFormatters:
+                    searchMode === 'all' ? [...valueFormatters, ...searchOptions] : searchOptions,
+            });
+        }
+    }
+    return (
+        <>
+            <SearchPickerDropdown
+                menuItems={[
+                    { title: 'All', onCLick: () => setSearchMode('all') },
+                    { title: 'ID and title (default) ', onCLick: () => setSearchMode('id/desc') },
+                ]}
+            />
+            <EdsSearch
+                hasValue={Boolean(searchText)}
+                size={200}
+                onChange={handleClear}
+                placeholder={getPlaceholderText(searchMode)}
+                onInput={handleInput}
+                value={searchText}
+                onKeyPress={(e) => {
+                    if (e.key === 'Enter') {
+                        searchText && doSearch(searchText);
+                    }
+                }}
+            />
+        </>
+    );
+};
+
+const EdsSearch = styled(Search)<{ hasValue: boolean }>`
+    border: ${({ hasValue }) =>
+        hasValue ? `1px solid ${tokens.colors.interactive.primary__resting.hex}` : 'none'};
+`;

--- a/packages/filter/src/lib/components/filterView/FilterView.tsx
+++ b/packages/filter/src/lib/components/filterView/FilterView.tsx
@@ -1,0 +1,31 @@
+import { useFilterController } from '../../hooks/useFilterContext';
+import { FilterGroup } from '../../types';
+import { ExpandedFilterGroup } from '../ExpandedFilterGroup/ExpandedFilterGroup';
+import { FilterGroups, FilterGroupWrapper, Wrapper } from './filterView.styles';
+
+interface FilterViewProps {
+    visibleFilterGroups: string[];
+}
+
+export const FilterView = ({ visibleFilterGroups }: FilterViewProps): JSX.Element => {
+    const { getGroupValues } = useFilterController();
+
+    return (
+        <Wrapper>
+            <FilterGroups>
+                {visibleFilterGroups
+                    .map(
+                        (groupName): FilterGroup => ({
+                            name: groupName,
+                            values: getGroupValues(groupName),
+                        })
+                    )
+                    .map((filterGroup, index) => (
+                        <FilterGroupWrapper key={`col-${filterGroup.name}-${index}`}>
+                            <ExpandedFilterGroup filterGroup={filterGroup} />
+                        </FilterGroupWrapper>
+                    ))}
+            </FilterGroups>
+        </Wrapper>
+    );
+};

--- a/packages/filter/src/lib/components/filterView/filterView.styles.ts
+++ b/packages/filter/src/lib/components/filterView/filterView.styles.ts
@@ -1,0 +1,96 @@
+import { Button } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+import styled from 'styled-components';
+
+export const Wrapper = styled.section`
+    display: flex;
+    flex-direction: row;
+    height: 200px;
+
+    background-color: ${tokens.colors.ui.background__light.rgba};
+    border-bottom: 1.5px solid ${tokens.colors.ui.background__medium.rgba};
+    transition: height 0.35s ease;
+    width: 100%;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    @keyframes fadeIn {
+        from {
+            opacity: 0;
+        }
+        to {
+            opacity: 1;
+        }
+    }
+    animation-duration: 0.5s;
+    animation-name: fadeIn;
+`;
+
+export const FilterSelect = styled.div`
+    display: flex;
+    flex-direction: column;
+    min-width: fit-content;
+    margin: 0rem 0.5rem 0rem 0.5rem;
+    padding-right: 0.5rem;
+    overflow: hidden;
+    border-right: 2px solid ${tokens.colors.ui.background__medium.rgba};
+
+    label {
+        padding: 0;
+        span {
+            font-size: 14px;
+            padding: 0;
+            :last-child {
+                padding-right: 0.5rem;
+            }
+        }
+        svg {
+            height: 16px;
+            width: 16px;
+        }
+    }
+`;
+export const FilterGroups = styled.div`
+    display: flex;
+    flex-direction: row;
+    overflow-y: hidden;
+    overflow-x: scroll;
+    width: -webkit-fill-available;
+    background-color: ${tokens.colors.ui.background__light.rgba};
+
+    ::-webkit-scrollbar {
+        height: 0.3rem;
+    }
+`;
+
+export const FilterGroupWrapper = styled.div``;
+
+export const SearchFilterWrapper = styled.div`
+    overflow-x: scroll;
+    height: -webkit-fill-available;
+
+    ::-webkit-scrollbar {
+        width: 0.3rem;
+    }
+`;
+
+export const SelectBar = styled.div`
+    display: flex;
+    flex-direction: column;
+    background-color: ${tokens.colors.ui.background__light.rgba};
+    border-right: 2px solid ${tokens.colors.ui.background__medium.rgba};
+`;
+
+export const AddButton = styled(Button)`
+    width: 36px;
+    height: 36px;
+`;
+export const SearchButton = styled(Button)`
+    width: 36px;
+    height: 36px;
+`;
+
+export const FilterSelectHeaderGroup = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;

--- a/packages/filter/src/lib/components/index.ts
+++ b/packages/filter/src/lib/components/index.ts
@@ -1,0 +1,1 @@
+export * from './quickFilter/QuickFilter';

--- a/packages/filter/src/lib/components/quickFilter/QuickFilter.tsx
+++ b/packages/filter/src/lib/components/quickFilter/QuickFilter.tsx
@@ -1,0 +1,145 @@
+import { createContext, useState } from 'react';
+
+import { CompactFilterWrapper, SearchLine, LeftSection, RightSection } from './quickFilterStyles';
+import { Chip } from '@equinor/eds-core-react';
+import styled from 'styled-components';
+import { tokens } from '@equinor/eds-tokens';
+import { FilterGroup } from '../filterGroup';
+import { FilterQuickSearch } from '../filterQuickSearch/FilterQuickSearch';
+import { ToggleHideFilterPopover } from '../ToggleHideFilterPopover';
+import { FilterClearIcon, FilterCollapseIcon, FilterExpandIcon } from '../../icons';
+import { FilterController } from '../../classes';
+import { FilterView } from '../filterView/FilterView';
+import { FilterConfiguration } from '../../types';
+import { useOnFilteredDataChanged } from '../../hooks/useOnFilteredDataChanged';
+
+/**
+ * How to separate controller and visual logic in this component?
+ */
+interface QuickFilterProps<T> {
+    controller: FilterController<T>;
+    groups: Omit<FilterConfiguration<T>, 'valueFormatter'>[];
+}
+
+export function QuickFilter<T>({
+    controller = new FilterController(),
+    groups,
+}: QuickFilterProps<T>): JSX.Element {
+    useOnFilteredDataChanged(controller.onFilterDataChange, controller.filteredData);
+
+    const [filterGroupOpen, setFilterGroupOpen] = useState<string | null>(null);
+    const { getInactiveGroupValues, clearActiveFilters, filterState, valueFormatters } = controller;
+
+    function checkHasActiveFilters() {
+        return filterState.length !== 0;
+    }
+
+    const handleExpandFilterGroup = (groupName: string) =>
+        filterGroupOpen === groupName ? setFilterGroupOpen(null) : setFilterGroupOpen(groupName);
+
+    const quickFilterGroups = groups
+        ?.filter(({ isQuickFilter }) => isQuickFilter)
+        .map(({ name }) => name);
+
+    const filterGroups = valueFormatters.map(({ name }) => name);
+
+    const [visibleFilterGroups, setVisibleFilterGroups] = useState<string[]>(
+        groups.filter((s) => !s.defaultHidden).map((s) => s.name)
+    );
+
+    const [isFilterExpanded, setIsFilterExpanded] = useState(false);
+
+    const toggleFilterIsExpanded = () => {
+        setIsFilterExpanded((s) => !s);
+        setFilterGroupOpen(null);
+    };
+
+    const calculateHiddenFiltersApplied = () =>
+        groups.reduce(
+            (acc, curr) =>
+                !curr.isQuickFilter && getInactiveGroupValues(curr.name).length > 0 ? acc + 1 : acc,
+            0
+        );
+
+    return (
+        <FilterContext.Provider value={controller as FilterController<unknown>}>
+            <Wrapper>
+                <CompactFilterWrapper>
+                    <SearchLine>
+                        <LeftSection>
+                            <FilterQuickSearch />
+                        </LeftSection>
+                        <RightSection>
+                            {!isFilterExpanded && (
+                                <>
+                                    {quickFilterGroups.map(
+                                        (group, i) =>
+                                            i < 5 && (
+                                                <FilterGroup
+                                                    onClick={() => handleExpandFilterGroup(group)}
+                                                    key={group}
+                                                    isOpen={filterGroupOpen === group}
+                                                    name={group}
+                                                />
+                                            )
+                                    )}
+                                    <OtherFiltersAppliedInfo
+                                        activeFilters={calculateHiddenFiltersApplied()}
+                                    />
+                                </>
+                            )}
+                            <div style={{ display: 'flex' }}>
+                                {isFilterExpanded && (
+                                    <ToggleHideFilterPopover
+                                        allFilters={filterGroups}
+                                        setVisibleFilters={setVisibleFilterGroups}
+                                        visibleFilters={visibleFilterGroups}
+                                    />
+                                )}
+                                <FilterClearIcon
+                                    isDisabled={!checkHasActiveFilters()}
+                                    onClick={() => clearActiveFilters()}
+                                />
+
+                                <div onClick={toggleFilterIsExpanded}>
+                                    {isFilterExpanded ? (
+                                        <FilterCollapseIcon />
+                                    ) : (
+                                        <FilterExpandIcon />
+                                    )}
+                                </div>
+                            </div>
+                        </RightSection>
+                    </SearchLine>
+                </CompactFilterWrapper>
+                {isFilterExpanded && <FilterView visibleFilterGroups={visibleFilterGroups} />}
+            </Wrapper>
+        </FilterContext.Provider>
+    );
+}
+
+const Wrapper = styled.div`
+    width: 100%;
+    overflow: scroll;
+`;
+
+interface OtherFiltersAppliedInfoProps {
+    activeFilters: number;
+}
+
+export function OtherFiltersAppliedInfo({
+    activeFilters,
+}: OtherFiltersAppliedInfoProps): JSX.Element | null {
+    if (activeFilters <= 0) return null;
+
+    return <InfoChip>+{activeFilters} other filters applied</InfoChip>;
+}
+
+const InfoChip = styled(Chip)`
+    background-color: ${tokens.colors.ui.background__info.hex};
+    color: ${tokens.colors.text.static_icons__default.hex};
+    font-weight: 500;
+    font-size: 12px;
+`;
+
+export const FilterContext = createContext<FilterController<unknown>>(new FilterController());

--- a/packages/filter/src/lib/components/quickFilter/quickFilterStyles.ts
+++ b/packages/filter/src/lib/components/quickFilter/quickFilterStyles.ts
@@ -1,0 +1,34 @@
+import { tokens } from '@equinor/eds-tokens';
+import styled from 'styled-components';
+
+export const CompactFilterWrapper = styled.div`
+    height: 50px;
+    width: 100%;
+    background-color: ${tokens.colors.ui.background__light.hex};
+`;
+
+export const LeftSection = styled.div`
+    display: flex;
+    align-items: center;
+    padding-left: 16px;
+    gap: 0.5em;
+`;
+
+export const RightSection = styled.div`
+    display: flex;
+    gap: 2em;
+    align-items: center;
+    padding-right: 2px;
+`;
+
+export const SearchLine = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+export const VerticalDivider = styled.div`
+    border-left: ${tokens.colors.ui.background__medium.hex} 2px solid;
+    height: 50px;
+    width: 2px;
+`;

--- a/packages/filter/src/lib/functions/doesItemPass.ts
+++ b/packages/filter/src/lib/functions/doesItemPass.ts
@@ -1,0 +1,38 @@
+import { FilterGroup, FilterValueType, ValueFormatterFilter } from '../types';
+import { findValueFormatter } from '../utils/findValueFormatter';
+
+export function doesItemPassFilter<T>(
+    item: T,
+    state: FilterGroup[],
+    valueFormatters: ValueFormatterFilter<T>[]
+): boolean {
+    /** Item must pass all the filters */
+    return state.every(({ name, values: uncheckedValues }) => {
+        const valueFormatterFunction = findValueFormatter(name, valueFormatters);
+        if (!valueFormatterFunction) return false;
+
+        const itemValue = valueFormatterFunction(item);
+        return doesItemPassCriteria(uncheckedValues, itemValue);
+    });
+}
+
+export function doesItemPassCriteria(
+    uncheckedValues: FilterValueType[],
+    value: FilterValueType | FilterValueType[]
+): boolean {
+    /**
+     * Item value is array
+     */
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return !uncheckedValues.includes(null);
+        }
+
+        /** All values in the array must be unchecked for filter to remove the item */
+        return !value.every((value) => uncheckedValues.includes(value));
+    } else {
+        /** Returns false if it finds the value */
+        /** Passes if the value is null */
+        return !uncheckedValues.includes(value);
+    }
+}

--- a/packages/filter/src/lib/functions/generateFilterValues.ts
+++ b/packages/filter/src/lib/functions/generateFilterValues.ts
@@ -1,0 +1,81 @@
+import { FilterGroup, FilterOptions, FilterValueType, ValueFormatterFilter } from '../types';
+
+export function generateFilterValues<T>(
+    valueFormatters: ValueFormatterFilter<T>[],
+    data: T[]
+): FilterGroup[] {
+    if (!data || data.length == 0) return [];
+    // Initialize all filter groups
+    const filterGroups: FilterGroup[] = valueFormatters.map(
+        ({ name }): FilterGroup => ({ name: name, values: [] })
+    );
+
+    /** Iterate all values */
+    data.forEach((item) =>
+        valueFormatters.forEach(({ name, valueFormatter }) => {
+            const filterGroup = filterGroups.find(
+                ({ name: filterGroupName }) => name === filterGroupName
+            );
+            /** Cant happen but ts */
+            if (!filterGroup) return;
+            const value = valueFormatter(item);
+
+            if (Array.isArray(value)) {
+                filterGroup.values = [
+                    ...filterGroup.values.filter((oldValue) => !value.includes(oldValue)),
+                    ...value,
+                ];
+            } else {
+                filterGroup.values = [
+                    ...filterGroup.values.filter((oldValue) => oldValue !== value),
+                    value,
+                ];
+            }
+        })
+    );
+
+    return sortFilterGroups(filterGroups, valueFormatters);
+}
+
+/**
+ * Sorts the filter items alphanumeric.
+ * PITFALL: Case sensitive sorting
+ * A > T > a
+ * @param groups
+ * @returns
+ */
+function sortFilterGroups<T = unknown>(
+    groups: FilterGroup[],
+    filterConfig: FilterOptions<T>
+): FilterGroup[] {
+    groups.forEach(({ values, name }) => {
+        const customSort = filterConfig.find(({ name: configName }) => name === configName)?.sort;
+
+        if (customSort) {
+            customSort(values);
+        } else {
+            values.sort(defaultSortFunction);
+        }
+    });
+    return groups;
+}
+
+function defaultSortFunction(a: FilterValueType, b: FilterValueType): number {
+    /** Place null values on top */
+    if (a === null) return -1;
+    if (b === null) return 1;
+
+    /** Ignore if a and b is not same type */
+    if (typeof b !== typeof a) return 0;
+
+    switch (typeof a) {
+        case 'number': {
+            //B has to be a number
+            return a - (b as number);
+        }
+
+        case 'string': {
+            return a.toLowerCase().localeCompare((b as string).toLowerCase());
+        }
+    }
+}

--- a/packages/filter/src/lib/functions/getPlaceholderText.ts
+++ b/packages/filter/src/lib/functions/getPlaceholderText.ts
@@ -1,0 +1,9 @@
+import { SearchMode } from '../types';
+
+export const getPlaceholderText = (searchMode: SearchMode): string => {
+    if (searchMode === 'all') {
+        return 'Free text search';
+    } else {
+        return 'Search for id or title';
+    }
+};

--- a/packages/filter/src/lib/functions/index.ts
+++ b/packages/filter/src/lib/functions/index.ts
@@ -1,0 +1,3 @@
+export * from './doesItemPass';
+export * from './generateFilterValues';
+export * from './searchAcrossFilterGroups';

--- a/packages/filter/src/lib/functions/registerCallback.ts
+++ b/packages/filter/src/lib/functions/registerCallback.ts
@@ -1,0 +1,18 @@
+import { Callback, OnCallbackSet } from '../classes';
+
+export function registerCallback<TCallback>(
+    cb: TCallback,
+    list: Callback<TCallback>[],
+    unsub: (id: string) => void
+): OnCallbackSet {
+    const id = generateUniqueId();
+    list.push({ callback: cb, id });
+    return {
+        id,
+        unSubscribe: () => unsub(id),
+    };
+}
+
+function generateUniqueId() {
+    return (Math.random() * 16).toString();
+}

--- a/packages/filter/src/lib/functions/searchAcrossFilterGroups.ts
+++ b/packages/filter/src/lib/functions/searchAcrossFilterGroups.ts
@@ -1,0 +1,32 @@
+import { ValueFormatterFilter } from '../types';
+
+/**
+ * Searchs for values matching atleast one of the filter groups values
+ * @param valueFormatters
+ * @param data
+ * @param searchValue
+ * @returns
+ */
+export function searchForStartsWith<T = unknown>(
+    valueFormatters: ValueFormatterFilter<T>[],
+    data: T[],
+    searchValue: string
+): T[] {
+    return data.filter((value) =>
+        valueFormatters.some(({ valueFormatter }) =>
+            valueFormatter(value)?.toString().toLowerCase().startsWith(searchValue)
+        )
+    );
+}
+
+export function searchForIncludes<T = unknown>(
+    valueFormatters: ValueFormatterFilter<T>[],
+    data: T[],
+    searchValue: string
+): T[] {
+    return data.filter((value) =>
+        valueFormatters.some(({ valueFormatter }) =>
+            valueFormatter(value)?.toString().toLowerCase().includes(searchValue)
+        )
+    );
+}

--- a/packages/filter/src/lib/hooks/useFilterContext.ts
+++ b/packages/filter/src/lib/hooks/useFilterContext.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+import { FilterController } from '../classes';
+import { FilterContext } from '../components/quickFilter/QuickFilter';
+
+export const useFilterController = <T>() => useContext(FilterContext) as FilterController<T>;

--- a/packages/filter/src/lib/hooks/useOnFilteredDataChanged.ts
+++ b/packages/filter/src/lib/hooks/useOnFilteredDataChanged.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+import { OnCallbackSet, OnFilterDataChangeCallback } from '../classes';
+
+export function useOnFilteredDataChanged<T>(
+    onFilterDataChange: (cb: OnFilterDataChangeCallback<T>) => OnCallbackSet,
+    initialData: T[]
+) {
+    const [val, setVal] = useState<T[]>(initialData);
+
+    useEffect(() => {
+        const { unSubscribe } = onFilterDataChange((data) => setVal(data));
+        return () => {
+            unSubscribe();
+        };
+    }, [onFilterDataChange]);
+
+    return val;
+}

--- a/packages/filter/src/lib/hooks/useOnFilteredDataChanged.ts
+++ b/packages/filter/src/lib/hooks/useOnFilteredDataChanged.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { OnCallbackSet, OnFilterDataChangeCallback } from '../classes';
+import { OnCallbackSet, OnFilterDataChangeCallback } from '../types';
 
 export function useOnFilteredDataChanged<T>(
     onFilterDataChange: (cb: OnFilterDataChangeCallback<T>) => OnCallbackSet,

--- a/packages/filter/src/lib/icons/FilterClearIcon.tsx
+++ b/packages/filter/src/lib/icons/FilterClearIcon.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@equinor/eds-core-react';
+import { tokens } from '@equinor/eds-tokens';
+
+interface FilterClearIconProps {
+    onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    isDisabled?: boolean;
+}
+
+export const FilterClearIcon = ({ onClick, isDisabled }: FilterClearIconProps): JSX.Element => (
+    <Button title="Clear filters" variant="ghost_icon" onClick={onClick} disabled={isDisabled}>
+        <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fill={isDisabled ? tokens.colors.interactive.disabled__text.hex : '#007079'}
+                fillRule="evenodd"
+                clipRule="evenodd"
+                d="M13.7601 15.187L21.0847 22.5116L22.4989 21.0974L14.0402 12.6387L14.0514 12.6243L5.4271 4H5.40152L2.79312 1.3916L1.37891 2.80582L3.83359 5.2605C3.86697 5.38124 3.92484 5.49967 4.01009 5.61C6.0301 8.2 9.76009 13 9.76009 13V19C9.76009 19.55 10.2101 20 10.7601 20H12.7601C13.3101 20 13.7601 19.55 13.7601 19V15.187ZM19.5001 5.61C18.3159 7.12834 16.5475 9.4062 15.2868 11.0313L8.25553 4H18.7101C19.5401 4 20.0101 4.95 19.5001 5.61Z"
+            />
+        </svg>
+    </Button>
+);

--- a/packages/filter/src/lib/icons/FilterCollapseIcon.tsx
+++ b/packages/filter/src/lib/icons/FilterCollapseIcon.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@equinor/eds-core-react';
+
+interface FilterCollapseIconProps {
+    onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}
+
+export const FilterCollapseIcon = ({ onClick }: FilterCollapseIconProps): JSX.Element => (
+    <Button title="Compact filter" variant="ghost_icon" onClick={onClick}>
+        <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                d="M20.207 4.29289C20.5975 4.68342 20.5975 5.31658 20.207 5.70711L16.4142 9.49985L19 9.5C19.5523 9.5 20 9.94772 20 10.5C20 11.0523 19.5523 11.5 19 11.5L14 11.5C13.4477 11.5 13 11.0523 13 10.5V5.5C13 4.94771 13.4477 4.5 14 4.5C14.5523 4.5 15 4.94771 15 5.5V8.08563L18.7927 4.29289C19.1833 3.90237 19.8164 3.90237 20.207 4.29289Z"
+                fill="#007079"
+            />
+            <path
+                d="M4.49985 14C4.49985 13.4477 4.94756 13 5.49985 13H10.4998C11.0521 13 11.4998 13.4477 11.4998 14L11.4998 19C11.4998 19.5523 11.0521 20 10.4998 20C9.94756 20 9.49985 19.5523 9.49985 19L9.49985 16.4144L5.70711 20.2071C5.31658 20.5976 4.68342 20.5976 4.29289 20.2071C3.90237 19.8166 3.90237 19.1834 4.29289 18.7929L8.08579 15L5.49985 15C4.94756 15 4.49985 14.5523 4.49985 14Z"
+                fill="#007079"
+            />
+        </svg>
+    </Button>
+);

--- a/packages/filter/src/lib/icons/FilterExpandIcon.tsx
+++ b/packages/filter/src/lib/icons/FilterExpandIcon.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@equinor/eds-core-react';
+
+interface FilterExpandIconProps {
+    onClick?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}
+
+export const FilterExpandIcon = ({ onClick }: FilterExpandIconProps): JSX.Element => (
+    <Button title="Advanced filter" onClick={onClick} variant="ghost_icon">
+        <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                d="M13 5C13 4.44772 13.4477 4 14 4H19C19.5523 4 20 4.44772 20 5V10C20 10.5523 19.5523 11 19 11C18.4477 11 18 10.5523 18 10V7.41436L14.2073 11.2071C13.8167 11.5976 13.1836 11.5976 12.793 11.2071C12.4025 10.8166 12.4025 10.1834 12.793 9.79289L16.5859 6H14C13.4477 6 13 5.55228 13 5Z"
+                fill="#007079"
+            />
+            <path
+                d="M11.207 14.2071C11.5975 13.8166 11.5975 13.1834 11.207 12.7929C10.8164 12.4024 10.1833 12.4024 9.79274 12.7929L6 16.5856L6 14C6 13.4477 5.55229 13 5 13C4.44772 13 4 13.4477 4 14V19C4 19.5523 4.44772 20 5 20L10 20C10.5523 20 11 19.5523 11 19C11 18.4477 10.5523 18 10 18H7.41406L11.207 14.2071Z"
+                fill="#007079"
+            />
+        </svg>
+    </Button>
+);

--- a/packages/filter/src/lib/icons/index.ts
+++ b/packages/filter/src/lib/icons/index.ts
@@ -1,0 +1,3 @@
+export * from './FilterClearIcon';
+export * from './FilterCollapseIcon';
+export * from './FilterExpandIcon';

--- a/packages/filter/src/lib/test/createFilterItems.spec.ts
+++ b/packages/filter/src/lib/test/createFilterItems.spec.ts
@@ -1,0 +1,118 @@
+import { generateFilterValues } from "../functions/generateFilterValues"
+import { FilterGroup, FilterOptions } from "../types";
+
+
+
+interface ScopeChangeRequest{
+    name: string;
+    originSource: string;
+    changeCategory: {name: string, id: string},
+}
+
+
+
+enum FilterNames {
+    Origin = "origin",
+    Category = "category"
+}
+
+
+const filterOptions: FilterOptions<ScopeChangeRequest> = [
+    {
+        name: FilterNames.Origin,
+        valueFormatter: ({ originSource }) => originSource
+    },
+    {
+        name: FilterNames.Category,
+        valueFormatter: ({ changeCategory }) => changeCategory.name
+    }
+]
+
+
+
+const expectedOutput: FilterGroup[] = [
+    {
+        name: FilterNames.Origin,
+        values: ["DCN", "NCR"]
+    },
+    {
+        name: FilterNames.Category,
+        values: ["Hidden Carry Over", "Quality"]
+    }
+]
+
+const mockData: ScopeChangeRequest[] = [
+    {
+        changeCategory: { id: "1", name: "Hidden Carry Over" },
+        originSource: "NCR"
+    },
+    {
+        changeCategory: { id: "2", name: "Hidden Carry Over" },
+        originSource: "DCN"
+    },
+    {
+        changeCategory: { id: "3", name: "Quality" },
+        originSource: "DCN"
+    }
+] as ScopeChangeRequest[]
+
+
+/**
+ * //TODO: Fix
+ *  Very sensitive to order and sorting 
+*/
+describe("Should create expected filter values", () => {
+    it("Should create filter items matching output", () => {
+        const result = generateFilterValues(filterOptions, mockData);
+        expect(result).toStrictEqual(expectedOutput)
+    })
+})
+
+
+
+interface Mock {
+    names: string[]
+}
+
+const mockArrayData: Mock[] = [
+    {
+        names: ["John", "Cena", "Jonas"]
+    },
+    {
+        names: ["Jane", "Doe", "John"]
+    },
+    {
+        names: ["Krista", "Doe", "John"]
+    },
+    {
+        names: []
+    }
+]
+
+const filterArrayOptions: FilterOptions<Mock> = [
+    {
+        name: "Name",
+        valueFormatter: ({ names }) => names
+    }
+]
+
+const expectedArrayOutput: FilterGroup[] = [
+    {
+        name: "Name",
+        values: ["Cena", "Doe", "Jane", "John", "Jonas", "Krista"]
+    }
+]
+
+
+
+describe("Create filter items from array", () => {
+    it("Should not have duplicates", () => {
+        const result = generateFilterValues(filterArrayOptions, mockArrayData)
+        expect(result).toStrictEqual(expectedArrayOutput)
+    })
+})
+
+
+
+
+

--- a/packages/filter/src/lib/test/doesItemPass.spec.ts
+++ b/packages/filter/src/lib/test/doesItemPass.spec.ts
@@ -1,0 +1,31 @@
+import { FilterController } from "../classes"
+
+
+
+
+interface MockInterface{
+    name: string;
+}
+
+const filterGroupName = "Name";
+const name1 = "Gustav";
+const name2 = "Jonas";
+
+
+
+describe("Does item pass filter", () => {
+    const controller = new FilterController<MockInterface>();
+    controller.addValueFormatters([{name: filterGroupName, valueFormatter: s => s.name}])
+    controller.setData([{name: name1}, {name: name2}])
+
+    it("Should pass", () => {
+        controller.setFilterState([{name: filterGroupName, values: [name1]}])
+        controller.filter();
+        expect(controller.filteredData.length).toBe(1)
+        expect(controller.filteredData.map((s) => s.name)).toContain(name2)
+
+
+        controller.setFilterState([]);
+        controller.filter();
+    }) 
+})

--- a/packages/filter/src/lib/test/searchItems.spec.ts
+++ b/packages/filter/src/lib/test/searchItems.spec.ts
@@ -1,0 +1,62 @@
+import { searchForStartsWith } from "../functions/searchAcrossFilterGroups"
+import { ValueFormatterFilter } from "../types"
+
+interface TestInterface{
+    name: string;
+    originSource: string;
+    changeCategory: {name: string, id: string},
+    title: string;
+}
+
+const items: TestInterface[] =
+    [
+        {
+            changeCategory: { name: "Hidden Carry Over", id: "2" },
+        },
+        {
+            changeCategory: { name: "Quality", id: 3 }
+        }
+    ] as TestInterface[]
+
+
+
+const valueFormatter: ValueFormatterFilter<TestInterface> = { name: "Change category", valueFormatter: ({ changeCategory }) => changeCategory.name }
+
+describe('Free text search across one filtergroup', () => {
+    it("One item should pass", () => {
+        const result = searchForStartsWith([valueFormatter], items, "hidden")
+        expect(result.length).toBe(1)
+    })
+})
+
+
+const mockRequests: TestInterface[] =
+    [
+        {
+            changeCategory: { name: "Hidden Carry Over", id: "2" },
+            title: "Mock request"
+        },
+        {
+            changeCategory: { name: "Quality", id: 3 },
+            title: "Mock request #2"
+        },
+        {
+            changeCategory: { name: "Late design change", id: 4 },
+            title: "Request #3"
+        }
+    ] as TestInterface[]
+
+
+
+const valueFormatters: ValueFormatterFilter<TestInterface>[] = [
+    { name: "Change category", valueFormatter: ({ changeCategory }) => changeCategory.name },
+    { name: "Title", valueFormatter: ({ title }) => title }
+]
+
+describe('Free text search across multiple filtergroups', () => {
+    it("Both items should pass", () => {
+        const result = searchForStartsWith(valueFormatters, mockRequests, "mock")
+        expect(result.length).toBe(2)
+    })
+})
+

--- a/packages/filter/src/lib/types/callback.ts
+++ b/packages/filter/src/lib/types/callback.ts
@@ -1,0 +1,10 @@
+
+export interface Callback<TCallback> {
+    id: string;
+    callback: TCallback;
+}
+
+export interface OnCallbackSet {
+    id: string;
+    unSubscribe: () => void;
+}

--- a/packages/filter/src/lib/types/events.ts
+++ b/packages/filter/src/lib/types/events.ts
@@ -1,0 +1,18 @@
+import { FilterController } from "../classes";
+import { FilterGroup } from "./filter";
+
+/**
+ * Callback to be fired when filter data changes
+ */
+export type OnFilterDataChangeCallback<TData> = (
+    data: TData[],
+    controller: FilterController<TData>
+) => void;
+
+/**
+ * Callback to be fired when filter state changes
+ */
+export type OnFilterStateChangedCallback<T> = (
+    newFilterState: FilterGroup[],
+    controller: FilterController<T>
+) => void;

--- a/packages/filter/src/lib/types/filter.ts
+++ b/packages/filter/src/lib/types/filter.ts
@@ -36,10 +36,7 @@ export interface FilterConfiguration<T> {
  * Primitive types allowed as filter types.
  */
 export type FilterValueType = string | number | null;
-/**
- * Defines which valueformatters to use for searching
- */
-export type SearchMode = 'id/desc' | 'all';
+
 /**
  * Function for formatting an object to a filter value
  */
@@ -55,26 +52,6 @@ export interface FilterGroup {
     name: string;
     values: FilterValueType[];
 }
-
-/**
- * Object to store for an active search, allows for searching after filtering has been done.
- */
-export interface FilterSearchActive<T> {
-    searchValue: string;
-    valueFormatters: ValueFormatterFilter<T>[];
-    searchIn: SearchDataSet;
-    type: SearchType;
-}
-
-/**
- * Defines which data to search in
- */
-export type SearchDataSet = 'Data' | 'FilteredData';
-
-/**
- * Different types for searching
- */
-export type SearchType = 'startsWith' | 'includes';
 
 export interface FilterItemCount {
     /** Item name */

--- a/packages/filter/src/lib/types/filter.ts
+++ b/packages/filter/src/lib/types/filter.ts
@@ -1,0 +1,83 @@
+/**
+ * All filter groups gathered in one type
+ */
+export type FilterOptions<T> = FilterConfiguration<T>[];
+
+/**
+ * Filter configuration for a given filter group
+ */
+export interface FilterConfiguration<T> {
+    name: string;
+    /** Takes in an item and returns the filter value */
+    valueFormatter: (item: T) => FilterValueType | FilterValueType[];
+    /** Should the filter be active in the pane on mount */
+    /**
+     * Insert a list of values to be default filtered
+     * Case insensitive
+     */
+    defaultUncheckedValues?: FilterValueType[];
+    /**
+     * Check if you want the filter to be hidden by default
+     */
+    defaultHidden?: boolean;
+
+    /**
+     * Adds the filter to the compact filter, MAX 5!
+     */
+    isQuickFilter?: boolean;
+
+    /** Sort the list of values in the filtergroup, defaults to alphanumeric */
+    sort?: (values: FilterValueType[]) => FilterValueType[];
+    /** Custom render function for rendering the value in the filter view */
+    customValueRender?: (value: FilterValueType) => JSX.Element;
+}
+
+/**
+ * Primitive types allowed as filter types.
+ */
+export type FilterValueType = string | number | null;
+/**
+ * Defines which valueformatters to use for searching
+ */
+export type SearchMode = 'id/desc' | 'all';
+/**
+ * Function for formatting an object to a filter value
+ */
+export type ValueFormatterFunction<T> = (item: T) => FilterValueType | FilterValueType[];
+
+export interface ValueFormatterFilter<T> {
+    name: string;
+    valueFormatter: ValueFormatterFunction<T>;
+    sort?: (values: FilterValueType[]) => FilterValueType[];
+}
+
+export interface FilterGroup {
+    name: string;
+    values: FilterValueType[];
+}
+
+/**
+ * Object to store for an active search, allows for searching after filtering has been done.
+ */
+export interface FilterSearchActive<T> {
+    searchValue: string;
+    valueFormatters: ValueFormatterFilter<T>[];
+    searchIn: SearchDataSet;
+    type: SearchType;
+}
+
+/**
+ * Defines which data to search in
+ */
+export type SearchDataSet = 'Data' | 'FilteredData';
+
+/**
+ * Different types for searching
+ */
+export type SearchType = 'startsWith' | 'includes';
+
+export interface FilterItemCount {
+    /** Item name */
+    name: FilterValueType;
+    count: number;
+}

--- a/packages/filter/src/lib/types/index.ts
+++ b/packages/filter/src/lib/types/index.ts
@@ -1,0 +1,1 @@
+export * from './filter';

--- a/packages/filter/src/lib/types/index.ts
+++ b/packages/filter/src/lib/types/index.ts
@@ -1,1 +1,4 @@
 export * from './filter';
+export * from './callback';
+export * from './events';
+export * from './search';

--- a/packages/filter/src/lib/types/search.ts
+++ b/packages/filter/src/lib/types/search.ts
@@ -1,0 +1,26 @@
+import { ValueFormatterFilter } from "./filter";
+
+/**
+ * Defines which data to search in
+ */
+ export type SearchDataSet = 'Data' | 'FilteredData';
+
+ /**
+  * Different types for searching
+  */
+ export type SearchType = 'startsWith' | 'includes';
+
+ /**
+ * Defines which valueformatters to use for searching
+ */
+export type SearchMode = 'id/desc' | 'all';
+
+/**
+ * Object to store for an active search, allows for searching after filtering has been done.
+ */
+ export interface FilterSearchActive<T> {
+    searchValue: string;
+    valueFormatters: ValueFormatterFilter<T>[];
+    searchIn: SearchDataSet;
+    type: SearchType;
+}

--- a/packages/filter/src/lib/utils/Switch.tsx
+++ b/packages/filter/src/lib/utils/Switch.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface SwitchProps {
+    children: React.ReactNode;
+    condition?: string | number | boolean | undefined | null | symbol;
+    defaultCase?: React.ReactChild;
+}
+
+export function Switch({ children, condition, defaultCase = <></> }: SwitchProps): JSX.Element {
+    const child = React.Children.toArray(children).find(
+        (child) =>
+            React.isValidElement(child) &&
+            (condition ? condition === child.props.when : child.props.when)
+    );
+
+    return <>{child || defaultCase}</>;
+}
+export interface CaseProps {
+    when: boolean | string | number | symbol | undefined | null;
+}
+export const Case = ({ children }: React.PropsWithChildren<CaseProps>): JSX.Element => {
+    return <>{children}</>;
+};

--- a/packages/filter/src/lib/utils/convertFromBlank.ts
+++ b/packages/filter/src/lib/utils/convertFromBlank.ts
@@ -1,0 +1,6 @@
+import { FilterValueType } from '../types';
+
+export const DEFAULT_NULL_VALUE = '(Blank)';
+export function convertFromBlank(name: FilterValueType) {
+    return name === DEFAULT_NULL_VALUE ? null : name;
+}

--- a/packages/filter/src/lib/utils/filterGroupExists.ts
+++ b/packages/filter/src/lib/utils/filterGroupExists.ts
@@ -1,0 +1,4 @@
+import { FilterGroup } from '../types';
+
+export const filterGroupExists = (groupName: string, filterState: FilterGroup[]): boolean =>
+    filterState.findIndex(({ name }) => name === groupName) !== -1;

--- a/packages/filter/src/lib/utils/findValueFormatter.ts
+++ b/packages/filter/src/lib/utils/findValueFormatter.ts
@@ -1,0 +1,15 @@
+import { ValueFormatterFilter, ValueFormatterFunction } from '../types';
+
+/**
+ * Finds value formatter for a given group
+ * Should never return undefined
+ * @param name
+ * @param valueFormatters
+ * @returns
+ */
+export function findValueFormatter<T>(
+    name: string,
+    valueFormatters: ValueFormatterFilter<T>[]
+): ValueFormatterFunction<T> | undefined {
+    return valueFormatters.find((formatter) => formatter.name === name)?.valueFormatter;
+}

--- a/packages/filter/src/lib/utils/index.ts
+++ b/packages/filter/src/lib/utils/index.ts
@@ -1,0 +1,3 @@
+export * from './findValueFormatter';
+export * from './shouldFilter';
+export * from './filterGroupExists';

--- a/packages/filter/src/lib/utils/searchByvalue.ts
+++ b/packages/filter/src/lib/utils/searchByvalue.ts
@@ -1,0 +1,3 @@
+export function searchByValue(items: string[], value: string) {
+    return items.filter((item) => item.toLocaleLowerCase().includes(value.toLocaleLowerCase()));
+}

--- a/packages/filter/src/lib/utils/shouldFilter.ts
+++ b/packages/filter/src/lib/utils/shouldFilter.ts
@@ -1,0 +1,6 @@
+import { FilterOptions } from '../types';
+
+export const shouldFilter = <T>(options: FilterOptions<T>): boolean =>
+    options.some(
+        ({ defaultUncheckedValues }) => defaultUncheckedValues && defaultUncheckedValues.length > 0
+    );

--- a/packages/filter/tsconfig.json
+++ b/packages/filter/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "allowJs": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ]
+}

--- a/packages/filter/tsconfig.lib.json
+++ b/packages/filter/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "types": ["node"]
+    },
+    "files": [
+        "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+        "../../node_modules/@nrwl/react/typings/image.d.ts"
+    ],
+    "exclude": [
+        "jest.config.ts",
+        "**/*.spec.ts",
+        "**/*.test.ts",
+        "**/*.spec.tsx",
+        "**/*.test.tsx",
+        "**/*.spec.js",
+        "**/*.test.js",
+        "**/*.spec.jsx",
+        "**/*.test.jsx"
+    ],
+    "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/packages/filter/tsconfig.spec.json
+++ b/packages/filter/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "jest.config.ts",
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@workspace/filter": ["packages/filter/src/index.ts"],
       "@workspace/garden": ["packages/garden/src/index.ts"],
       "@workspace/power-bi": ["packages/power-bi/src/index.ts"],
       "@workspace/table": ["packages/table/src/index.ts"],


### PR DESCRIPTION
# Description

Filter copied from the Castberg Project portal. Did some rewriting and split it into controller and view. Only thing i'm struggling with is the coupling between controller and view in props. 
I.E
Controller can have a filter group called "name". If you want to add a custom render method to this group it doesnt concern the controller. But the view uses the controller to find the groups. Suddenly you have an implicit coupling between the controller and view. The custom render needs to reference the name "name". Slippery slope to loose strings 

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [ ] My code is easy to read.
- [ ] Documentation and comments is added where needed.
- [ ] My code is covered by tests.
