### PR TITLE
AG-Grid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2048,9 +2048,9 @@
       }
     },
     "@nrwl/nx-cloud": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/@nrwl/nx-cloud/-/nx-cloud-14.1.3.tgz",
-      "integrity": "sha512-8Kn2xeKLTnifsZrNimOwl8Q1dJUWx+HwOC/0MeFgTySKcKE0eim81ST8xiaysNw6EyYT6y/vhPGMxby22wtqYQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/@nrwl/nx-cloud/-/nx-cloud-14.3.0.tgz",
+      "integrity": "sha512-aByHe8Gp1/IT9CtQYlGLIYBgU+ZtrgEwblBX8kcoBNRPf1OOdouahjyasAjQ9zi1cznve8AzTTcLt2eSCHWfrw==",
       "dev": true,
       "requires": {
         "axios": "^0.21.1",
@@ -3597,6 +3597,19 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
+    },
+    "ag-grid-community": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-28.1.0.tgz",
+      "integrity": "sha512-iCrdRWImvj6pOKaRQXdaPfZ0EI4fCQgTVv5PiCP9otbDPQBxyxjFVn+jEoV0umOqpqPAMoDIbG9poKyWuHl/EA=="
+    },
+    "ag-grid-react": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-28.1.0.tgz",
+      "integrity": "sha512-4Z/7T5kYKWqUhDrSY6bgseiKLiuMwjG4zHYIVtZwGwma7hb5e2CYwDdnfoWKArR6a7TzF86JiRpzd2WlLaARdQ==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
     },
     "agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "dependencies": {
     "@equinor/eds-core-react": "^0.20.4",
     "@equinor/eds-tokens": "^0.7.1",
+    "ag-grid-community": "^28.1.0",
+    "ag-grid-react": "^28.1.0",
     "core-js": "^3.6.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/ag-grid/.babelrc
+++ b/packages/ag-grid/.babelrc
@@ -1,0 +1,12 @@
+{
+    "presets": [
+        [
+            "@nrwl/react/babel",
+            {
+                "runtime": "automatic",
+                "useBuiltIns": "usage"
+            }
+        ]
+    ],
+    "plugins": [["styled-components", { "pure": true, "ssr": true }]]
+}

--- a/packages/ag-grid/.eslintrc.json
+++ b/packages/ag-grid/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+    "extends": ["plugin:@nrwl/nx/react", "../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.ts", "*.tsx"],
+            "rules": {}
+        },
+        {
+            "files": ["*.js", "*.jsx"],
+            "rules": {}
+        }
+    ]
+}

--- a/packages/ag-grid/README.md
+++ b/packages/ag-grid/README.md
@@ -1,0 +1,7 @@
+# ag-grid
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test ag-grid` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/ag-grid/README.md
+++ b/packages/ag-grid/README.md
@@ -2,6 +2,15 @@
 
 The purpose of this ag grid wrapper is to persist viewstate in the controller while the view is unmounted, currently not supported natively by AG-Grid.
 
+## Usage example
+
+```ts
+const gridController = new GridController()
+gridController.colDefs = [{field: "id"}]
+
+<Grid controller=gridController />
+```
+
 ## Running unit tests
 
 Run `nx test ag-grid` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/ag-grid/README.md
+++ b/packages/ag-grid/README.md
@@ -1,6 +1,6 @@
 # ag-grid
 
-This library was generated with [Nx](https://nx.dev).
+The purpose of this ag grid wrapper is to persist viewstate in the controller while the view is unmounted, currently not supported natively by AG-Grid.
 
 ## Running unit tests
 

--- a/packages/ag-grid/jest.config.ts
+++ b/packages/ag-grid/jest.config.ts
@@ -1,0 +1,10 @@
+/* eslint-disable */
+export default {
+    displayName: 'ag-grid',
+    preset: '../../jest.preset.js',
+    transform: {
+        '^.+\\.[tj]sx?$': 'babel-jest',
+    },
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+    coverageDirectory: '../../coverage/packages/ag-grid',
+};

--- a/packages/ag-grid/package.json
+++ b/packages/ag-grid/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "@equinor/workspace-ag-grid",
+    "version": "0.0.1"
+}

--- a/packages/ag-grid/project.json
+++ b/packages/ag-grid/project.json
@@ -1,0 +1,52 @@
+{
+    "$schema": "..\\..\\node_modules\\nx\\schemas\\project-schema.json",
+    "sourceRoot": "packages/ag-grid/src",
+    "projectType": "library",
+    "tags": [],
+    "targets": {
+        "build": {
+            "executor": "@nrwl/js:tsc",
+            "outputs": [
+                "{options.outputPath}"
+            ],
+            "dependsOn": [
+                "^build"
+            ],
+            "options": {
+                "outputPath": "dist/packages/ag-grid",
+                "main": "packages/ag-grid/src/index.ts",
+                "tsConfig": "packages/ag-grid/tsconfig.lib.json",
+                "assets": [
+                    "packages/ag-grid/*.md"
+                ]
+            }
+        },
+        "publish": {
+            "executor": "@nrwl/workspace:run-commands",
+            "options": {
+                "command": "node tools/scripts/publish.mjs ag-grid {args.ver} {args.tag}"
+            },
+            "dependsOn": [
+                {
+                    "projects": "self",
+                    "target": "build"
+                }
+            ]
+        },
+        "lint": {
+            "executor": "@nrwl/linter:eslint",
+            "outputs": ["{options.outputFile}"],
+            "options": {
+                "lintFilePatterns": ["packages/ag-grid/**/*.{ts,tsx,js,jsx}"]
+            }
+        },
+        "test": {
+            "executor": "@nrwl/jest:jest",
+            "outputs": ["coverage/packages/ag-grid"],
+            "options": {
+                "jestConfig": "packages/ag-grid/jest.config.ts",
+                "passWithNoTests": true
+            }
+        }
+    }
+}

--- a/packages/ag-grid/src/index.ts
+++ b/packages/ag-grid/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib';
+

--- a/packages/ag-grid/src/lib/classes/gridController.ts
+++ b/packages/ag-grid/src/lib/classes/gridController.ts
@@ -1,11 +1,12 @@
 import { ColDef, GridOptions } from 'ag-grid-community';
-import { registerCallback } from '../functions/registerCallback';
+import { registerCallback } from '../functions';
 import {
     Callback,
     OnCallbackSet,
     OnGridOptionsChangedCallback,
     OnRowDataChangedCallback,
 } from '../types';
+
 
 export class GridController<T> {
     rowData: T[] = [];
@@ -15,13 +16,23 @@ export class GridController<T> {
     /**
      * Callbacks
      */
-    onRowDataChangedCallbacks: Callback<OnRowDataChangedCallback<T>>[] = [];
-    onGridOptionsChangedCallbacks: Callback<OnGridOptionsChangedCallback<T>>[] = [];
+    private onRowDataChangedCallbacks: Callback<OnRowDataChangedCallback<T>>[] = [];
+    private onGridOptionsChangedCallbacks: Callback<OnGridOptionsChangedCallback<T>>[] = [];
 
+    /**
+     * Updates the grid options
+     * @param gridOptions 
+     */
     setGridOptions = (gridOptions: GridOptions) => {
         this.gridOptions = gridOptions;
         this.onGridOptionsChangedCallbacks.forEach(({callback}) => callback(gridOptions, this))
     };
+
+    /**
+     * Registers a function to be called upon when grid options changes
+     * @param cb 
+     * @returns 
+     */
     onGridOptionsChanged = (cb: OnGridOptionsChangedCallback<T>) =>
         registerCallback(cb, this.onGridOptionsChangedCallbacks, this.unsubOnGridOptionsChanged);
 
@@ -31,11 +42,20 @@ export class GridController<T> {
         );
     };
 
+    /**
+     * Sets new row data and triggers all the onRowDataChanged callback's.
+     * @param newData 
+     */
     setRowData = (newData: T[]) => {
         this.rowData = newData;
         this.onRowDataChangedCallbacks.forEach(({ callback }) => callback(newData, this));
     };
 
+    /**
+     * Registers a function to be called upon when row data changes
+     * @param callback 
+     * @returns 
+     */
     onRowDataChanged = (callback: OnRowDataChangedCallback<T>): OnCallbackSet =>
         registerCallback(callback, this.onRowDataChangedCallbacks, this.unsubOnRowDataChanged);
 

--- a/packages/ag-grid/src/lib/classes/gridController.ts
+++ b/packages/ag-grid/src/lib/classes/gridController.ts
@@ -1,0 +1,45 @@
+import { ColDef, GridOptions } from 'ag-grid-community';
+import { registerCallback } from '../functions/registerCallback';
+import {
+    Callback,
+    OnCallbackSet,
+    OnGridOptionsChangedCallback,
+    OnRowDataChangedCallback,
+} from '../types';
+
+export class GridController<T> {
+    rowData: T[] = [];
+    columnDefs: ColDef[] = [];
+    gridOptions: GridOptions | undefined = undefined;
+
+    /**
+     * Callbacks
+     */
+    onRowDataChangedCallbacks: Callback<OnRowDataChangedCallback<T>>[] = [];
+    onGridOptionsChangedCallbacks: Callback<OnGridOptionsChangedCallback<T>>[] = [];
+
+    setGridOptions = (gridOptions: GridOptions) => {
+        this.gridOptions = gridOptions;
+        this.onGridOptionsChangedCallbacks.forEach(({callback}) => callback(gridOptions, this))
+    };
+    onGridOptionsChanged = (cb: OnGridOptionsChangedCallback<T>) =>
+        registerCallback(cb, this.onGridOptionsChangedCallbacks, this.unsubOnGridOptionsChanged);
+
+    private unsubOnGridOptionsChanged = (id: string) => {
+        this.onGridOptionsChangedCallbacks = this.onGridOptionsChangedCallbacks.filter(
+            (s) => s.id !== id
+        );
+    };
+
+    setRowData = (newData: T[]) => {
+        this.rowData = newData;
+        this.onRowDataChangedCallbacks.forEach(({ callback }) => callback(newData, this));
+    };
+
+    onRowDataChanged = (callback: OnRowDataChangedCallback<T>): OnCallbackSet =>
+        registerCallback(callback, this.onRowDataChangedCallbacks, this.unsubOnRowDataChanged);
+
+    private unsubOnRowDataChanged = (id: string) => {
+        this.onRowDataChangedCallbacks = this.onRowDataChangedCallbacks.filter((s) => s.id !== id);
+    };
+}

--- a/packages/ag-grid/src/lib/classes/gridController.ts
+++ b/packages/ag-grid/src/lib/classes/gridController.ts
@@ -9,8 +9,11 @@ import {
 
 
 export class GridController<T> {
+    /** The data to be used in the grid */
     rowData: T[] = [];
+    /** The column definitions for the grid */
     columnDefs: ColDef[] = [];
+    /** The grid options to be used in the grid */
     gridOptions: GridOptions | undefined = undefined;
 
     /**
@@ -21,7 +24,7 @@ export class GridController<T> {
 
     /**
      * Updates the grid options
-     * @param gridOptions 
+     * @param gridOptions new grid options
      */
     setGridOptions = (gridOptions: GridOptions) => {
         this.gridOptions = gridOptions;
@@ -30,8 +33,8 @@ export class GridController<T> {
 
     /**
      * Registers a function to be called upon when grid options changes
-     * @param cb 
-     * @returns 
+     * @param cb The callback to be called on whenever grid options changes
+     * @returns The given id for the callback, and a function for unsubscribing.
      */
     onGridOptionsChanged = (cb: OnGridOptionsChangedCallback<T>) =>
         registerCallback(cb, this.onGridOptionsChangedCallbacks, this.unsubOnGridOptionsChanged);
@@ -44,7 +47,7 @@ export class GridController<T> {
 
     /**
      * Sets new row data and triggers all the onRowDataChanged callback's.
-     * @param newData 
+     * @param newData the new data to be set
      */
     setRowData = (newData: T[]) => {
         this.rowData = newData;
@@ -53,8 +56,8 @@ export class GridController<T> {
 
     /**
      * Registers a function to be called upon when row data changes
-     * @param callback 
-     * @returns 
+     * @param callback The callback to be called on whenever row data changes
+     * @returns The given id for the callback, and a function for unsubscribing.
      */
     onRowDataChanged = (callback: OnRowDataChangedCallback<T>): OnCallbackSet =>
         registerCallback(callback, this.onRowDataChangedCallbacks, this.unsubOnRowDataChanged);

--- a/packages/ag-grid/src/lib/classes/index.ts
+++ b/packages/ag-grid/src/lib/classes/index.ts
@@ -1,0 +1,1 @@
+export * from './gridController';

--- a/packages/ag-grid/src/lib/components/Grid.tsx
+++ b/packages/ag-grid/src/lib/components/Grid.tsx
@@ -3,21 +3,19 @@ import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-alpine.css';
 
 import { GridController } from '../classes/gridController';
+import { useRowData } from '../hooks/useRowData';
 
 interface GridProps<T> {
     controller: GridController<T>;
 }
 
 export function Grid<T>({ controller }: GridProps<T>) {
-    /** TODO: Make a wrapper for this! */
-
-
     return (
         <div className="ag-theme-alpine" style={{ height: 1000, width: 1200 }}>
             <AgGridReact
                 gridOptions={controller.gridOptions}
                 columnDefs={controller.columnDefs}
-                rowData={controller.rowData}
+                rowData={useRowData(controller)}
             />
         </div>
     );

--- a/packages/ag-grid/src/lib/components/Grid.tsx
+++ b/packages/ag-grid/src/lib/components/Grid.tsx
@@ -1,0 +1,24 @@
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/dist/styles/ag-grid.css';
+import 'ag-grid-community/dist/styles/ag-theme-alpine.css';
+
+import { GridController } from '../classes/gridController';
+
+interface GridProps<T> {
+    controller: GridController<T>;
+}
+
+export function Grid<T>({ controller }: GridProps<T>) {
+    /** TODO: Make a wrapper for this! */
+
+
+    return (
+        <div className="ag-theme-alpine" style={{ height: 1000, width: 1200 }}>
+            <AgGridReact
+                gridOptions={controller.gridOptions}
+                columnDefs={controller.columnDefs}
+                rowData={controller.rowData}
+            />
+        </div>
+    );
+}

--- a/packages/ag-grid/src/lib/components/index.ts
+++ b/packages/ag-grid/src/lib/components/index.ts
@@ -1,0 +1,1 @@
+export { Grid } from './Grid';

--- a/packages/ag-grid/src/lib/functions/index.ts
+++ b/packages/ag-grid/src/lib/functions/index.ts
@@ -1,0 +1,1 @@
+export * from './registerCallback'

--- a/packages/ag-grid/src/lib/functions/registerCallback.ts
+++ b/packages/ag-grid/src/lib/functions/registerCallback.ts
@@ -9,7 +9,7 @@ export function registerCallback<TCallback>(
     list.push({ callback: cb, id });
     return {
         id,
-        unSubscribe: () => unsub(id),
+        unsubscribe: () => unsub(id),
     };
 }
 

--- a/packages/ag-grid/src/lib/functions/registerCallback.ts
+++ b/packages/ag-grid/src/lib/functions/registerCallback.ts
@@ -1,0 +1,18 @@
+import { Callback, OnCallbackSet } from '../types';
+
+export function registerCallback<TCallback>(
+    cb: TCallback,
+    list: Callback<TCallback>[],
+    unsub: (id: string) => void
+): OnCallbackSet {
+    const id = generateUniqueId();
+    list.push({ callback: cb, id });
+    return {
+        id,
+        unSubscribe: () => unsub(id),
+    };
+}
+
+function generateUniqueId() {
+    return (Math.random() * 16).toString();
+}

--- a/packages/ag-grid/src/lib/hooks/index.ts
+++ b/packages/ag-grid/src/lib/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useRowData'

--- a/packages/ag-grid/src/lib/hooks/useRowData.ts
+++ b/packages/ag-grid/src/lib/hooks/useRowData.ts
@@ -5,7 +5,7 @@ export function useRowData<TData>(controller: GridController<TData>){
     const [rowData, setRowData] = useState(controller.rowData);
 
     useEffect(() => {
-        const {unSubscribe} = controller.onRowDataChanged(setRowData);
+        const {unsubscribe: unSubscribe} = controller.onRowDataChanged(setRowData);
         return unSubscribe
     },[controller])
 

--- a/packages/ag-grid/src/lib/hooks/useRowData.ts
+++ b/packages/ag-grid/src/lib/hooks/useRowData.ts
@@ -5,8 +5,8 @@ export function useRowData<TData>(controller: GridController<TData>){
     const [rowData, setRowData] = useState(controller.rowData);
 
     useEffect(() => {
-        const {unsubscribe: unSubscribe} = controller.onRowDataChanged(setRowData);
-        return unSubscribe
+        const { unsubscribe } = controller.onRowDataChanged(setRowData);
+        return unsubscribe
     },[controller])
 
     return rowData;

--- a/packages/ag-grid/src/lib/hooks/useRowData.ts
+++ b/packages/ag-grid/src/lib/hooks/useRowData.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+import { GridController } from "../classes";
+
+export function useRowData<TData>(controller: GridController<TData>){
+    const [rowData, setRowData] = useState(controller.rowData);
+
+    useEffect(() => {
+        const {unSubscribe} = controller.onRowDataChanged(setRowData);
+        return unSubscribe
+    },[controller])
+
+    return rowData;
+
+}

--- a/packages/ag-grid/src/lib/index.ts
+++ b/packages/ag-grid/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './components';
 export * from './types';
+export * from './hooks';
 export * from './classes';

--- a/packages/ag-grid/src/lib/index.ts
+++ b/packages/ag-grid/src/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './components';
+export * from './types';
+export * from './classes';

--- a/packages/ag-grid/src/lib/test/onGridOptionsChanged.spec.ts
+++ b/packages/ag-grid/src/lib/test/onGridOptionsChanged.spec.ts
@@ -7,7 +7,7 @@ const gridController = new GridController();
 /**
  * Test to make sure the onGridOptionsChanged callbacks are called and passing the correct data
  */
-describe('onGridOptionsChanged', () => {
+describe('Tests for validating that onGridOptionsChanged works', () => {
     it('Should call the onGridOptionsChanged', () => {
       
         gridController.onGridOptionsChanged((s) => {

--- a/packages/ag-grid/src/lib/test/onGridOptionsChanged.spec.ts
+++ b/packages/ag-grid/src/lib/test/onGridOptionsChanged.spec.ts
@@ -1,0 +1,21 @@
+import { GridController } from '../classes';
+
+const mocFunction = jest.fn();
+
+const gridController = new GridController();
+
+/**
+ * Test to make sure the onGridOptionsChanged callbacks are called and passing the correct data
+ */
+describe('onGridOptionsChanged', () => {
+    it('Should call the onGridOptionsChanged', () => {
+      
+        gridController.onGridOptionsChanged((s) => {
+            mocFunction();
+            expect(s.debug).toBe(true);
+        });
+        gridController.setGridOptions({debug: true});
+        expect(mocFunction).toBeCalled();
+        expect(mocFunction).toBeCalledTimes(1);
+    });
+});

--- a/packages/ag-grid/src/lib/test/onRowDataChanged.spec.ts
+++ b/packages/ag-grid/src/lib/test/onRowDataChanged.spec.ts
@@ -1,0 +1,21 @@
+import { GridController } from '../classes';
+
+const mocFunction = jest.fn();
+
+const gridController = new GridController();
+
+/**
+ * Test to make sure the onRowDataChanged callbacks are called and passing the correct data
+ */
+describe('OnRowDataChangedCallback', () => {
+    it('Should call the onRowDataChangedCallback', () => {
+        expect(gridController.rowData.length).toBe(0);
+        gridController.onRowDataChanged((s) => {
+            mocFunction();
+            expect(s.length).toBe(2);
+        });
+        gridController.setRowData([1, 2]);
+        expect(mocFunction).toBeCalled();
+        expect(mocFunction).toBeCalledTimes(1);
+    });
+});

--- a/packages/ag-grid/src/lib/test/onRowDataChanged.spec.ts
+++ b/packages/ag-grid/src/lib/test/onRowDataChanged.spec.ts
@@ -7,7 +7,7 @@ const gridController = new GridController();
 /**
  * Test to make sure the onRowDataChanged callbacks are called and passing the correct data
  */
-describe('OnRowDataChangedCallback', () => {
+describe('Tests for validating that callbacks are called when row data changes works', () => {
     it('Should call the onRowDataChangedCallback', () => {
         expect(gridController.rowData.length).toBe(0);
         gridController.onRowDataChanged((s) => {

--- a/packages/ag-grid/src/lib/test/onRowDataChanged.spec.ts
+++ b/packages/ag-grid/src/lib/test/onRowDataChanged.spec.ts
@@ -7,7 +7,7 @@ const gridController = new GridController();
 /**
  * Test to make sure the onRowDataChanged callbacks are called and passing the correct data
  */
-describe('Tests for validating that callbacks are called when row data changes works', () => {
+describe('Validates that callbacks are called when row data changes', () => {
     it('Should call the onRowDataChangedCallback', () => {
         expect(gridController.rowData.length).toBe(0);
         gridController.onRowDataChanged((s) => {

--- a/packages/ag-grid/src/lib/test/registerCallback.spec.ts
+++ b/packages/ag-grid/src/lib/test/registerCallback.spec.ts
@@ -1,0 +1,11 @@
+import { GridController } from "../classes"
+
+describe("Should add callback to array", () => {
+    it("Callback with corresponding id should be present", () => {
+        const controller = new GridController();
+        const {id, unSubscribe} = controller.onRowDataChanged(s => s)
+        expect(controller.onRowDataChangedCallbacks.map((s) => s.id).includes(id)).toBeTruthy()
+        unSubscribe();
+        expect(controller.onRowDataChangedCallbacks.map((s) => s.id).includes(id)).toBeFalsy()
+    })
+})

--- a/packages/ag-grid/src/lib/test/registerCallback.spec.ts
+++ b/packages/ag-grid/src/lib/test/registerCallback.spec.ts
@@ -3,9 +3,9 @@ import { GridController } from "../classes"
 describe("Should add callback to array", () => {
     it("Callback with corresponding id should be present", () => {
         const controller = new GridController();
-        const {id, unSubscribe} = controller.onRowDataChanged(s => s)
+        const {id, unsubscribe} = controller.onRowDataChanged(s => s)
         expect(controller.onRowDataChangedCallbacks.map((s) => s.id).includes(id)).toBeTruthy()
-        unSubscribe();
+        unsubscribe();
         expect(controller.onRowDataChangedCallbacks.map((s) => s.id).includes(id)).toBeFalsy()
     })
 })

--- a/packages/ag-grid/src/lib/types/callback.ts
+++ b/packages/ag-grid/src/lib/types/callback.ts
@@ -11,5 +11,5 @@ export interface Callback<TCallback> {
  */
 export interface OnCallbackSet {
     id: string;
-    unSubscribe: () => void;
+    unsubscribe: () => void;
 }

--- a/packages/ag-grid/src/lib/types/callback.ts
+++ b/packages/ag-grid/src/lib/types/callback.ts
@@ -1,0 +1,15 @@
+/**
+ * Wrapper for callback in controller class
+ */
+export interface Callback<TCallback> {
+    id: string;
+    callback: TCallback;
+}
+
+/**
+ * Return value for when a callback has been registered
+ */
+export interface OnCallbackSet {
+    id: string;
+    unSubscribe: () => void;
+}

--- a/packages/ag-grid/src/lib/types/events.ts
+++ b/packages/ag-grid/src/lib/types/events.ts
@@ -1,0 +1,15 @@
+import { GridOptions } from 'ag-grid-community';
+import { GridController } from '../classes';
+
+/**
+ * Callback function to be called when row data changes
+ */
+export type OnRowDataChangedCallback<T> = (newData: T[], controller: GridController<T>) => void;
+
+/**
+ * Callback function to be called when gridoptions change
+ */
+export type OnGridOptionsChangedCallback<T> = (
+    gridOptions: GridOptions,
+    controller: GridController<T>
+) => void;

--- a/packages/ag-grid/src/lib/types/gridConfig.ts
+++ b/packages/ag-grid/src/lib/types/gridConfig.ts
@@ -1,0 +1,5 @@
+import { ColDef } from 'ag-grid-community';
+
+export interface GridConfig {
+    colDefs: ColDef[];
+}

--- a/packages/ag-grid/src/lib/types/index.ts
+++ b/packages/ag-grid/src/lib/types/index.ts
@@ -1,0 +1,3 @@
+export * from './gridConfig';
+export * from './callback';
+export * from './events';

--- a/packages/ag-grid/tsconfig.json
+++ b/packages/ag-grid/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "allowJs": true,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ]
+}

--- a/packages/ag-grid/tsconfig.lib.json
+++ b/packages/ag-grid/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "types": ["node"]
+    },
+    "files": [
+        "../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
+        "../../node_modules/@nrwl/react/typings/image.d.ts"
+    ],
+    "exclude": [
+        "jest.config.ts",
+        "**/*.spec.ts",
+        "**/*.test.ts",
+        "**/*.spec.tsx",
+        "**/*.test.tsx",
+        "**/*.spec.js",
+        "**/*.test.js",
+        "**/*.spec.jsx",
+        "**/*.test.jsx"
+    ],
+    "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/packages/ag-grid/tsconfig.spec.json
+++ b/packages/ag-grid/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "include": [
+        "jest.config.ts",
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.tsx",
+        "**/*.spec.tsx",
+        "**/*.test.js",
+        "**/*.spec.js",
+        "**/*.test.jsx",
+        "**/*.spec.jsx",
+        "**/*.d.ts"
+    ]
+}

--- a/packages/test-app/src/app/app.tsx
+++ b/packages/test-app/src/app/app.tsx
@@ -49,14 +49,6 @@ interface Controllers<T>{
 }
 
 
-const CustomCellRender = (props: unknown) => {
-  return (
-    <div>
-      hello
-    </div>
-  )
-}
-
 
 
 function createGridController(){

--- a/packages/test-app/src/app/app.tsx
+++ b/packages/test-app/src/app/app.tsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
 
 import { Route, Routes, Link } from 'react-router-dom';
-import {Garden, GardenOptions} from '@workspace/garden'
+import { Grid, GridController } from '@workspace/grid'
 import { tokens } from '@equinor/eds-tokens';
+import { useState } from 'react';
+import { WorkspaceController } from '@workspace/workspace-core';
+import { Button } from '@equinor/eds-core-react';
 const StyledApp = styled.div`
  background-color: ${tokens.colors.ui.background__default.hex};
  height: 100%;
@@ -34,20 +37,48 @@ function Navbar(){
     <StyledNavbar>
       <StyledLink to="/">Home</StyledLink>
       <StyledLink to="/garden">Garden</StyledLink>
-      <StyledLink to="/table">Table</StyledLink>
+      <StyledLink to="/grid">Grid</StyledLink>
       <StyledLink to="/workspace">Workspace</StyledLink>
     </StyledNavbar>
   )
 }
 
+interface Controllers<T>{
+  grid: GridController<T>
+}
 
 
+function createGridController(){
+  const gridController = new GridController();
+  gridController.columnDefs = [{field: "id", resizable: true, sortable: true},{field: "title", resizable: true, sortable: true},{field: "sequenceNumber", resizable: true, sortable: true},{field: "description", resizable: true, sortable: true} ]
+
+  return gridController;
+}
+
+
+function createWorkspaceController(){
+  const wc = new WorkspaceController<DefaultInterface, Controllers<DefaultInterface>, unknown, unknown, unknown>();
+  wc.setData(mockData);
+  wc.setFilteredData(mockData);
+  wc.addController({controller: createGridController(), name: "grid", config: (gc, wc) => {
+    gc.setRowData(wc.getFilteredData())
+    wc.onFilteredDataChanged((data) => gc.setRowData(data))
+  }})
+
+  return wc;
+}
 
 export function App() {
+
+
+  const [workspaceController] = useState(createWorkspaceController())
+
+
   return (
     <StyledApp>
    
      <Navbar />
+     <Button onClick={() => workspaceController.setFilteredData([{id: "1213", title: "String", sequenceNumber: 1212, description: "Some desc"} as any])}>Change filtered data</Button>
       <Routes>
         <Route
           path="/"
@@ -57,10 +88,10 @@ export function App() {
           }
         />
         <Route
-          path="/garden"
+          path="/grid"
           element={
             <div>
-              <Garden data={mockData} gardenOptions={defaultGardenOptions} />
+              <Grid controller={workspaceController.controllers.grid} />
             </div>
           }
         />
@@ -95,17 +126,6 @@ interface Scope{
 }
 
 
-const defaultGardenOptions: GardenOptions<DefaultInterface> = {
-  gardenKey: "id",
-  itemKey: "title",
-  objectIdentifier: "id",
-  fieldSettings: {
-    Title: {
-      key: "title",
-      label: "Title"
-      }
-  }
-}
 
 
 const mockData = [

--- a/packages/test-app/src/app/app.tsx
+++ b/packages/test-app/src/app/app.tsx
@@ -6,6 +6,7 @@ import { tokens } from '@equinor/eds-tokens';
 import { useState } from 'react';
 import { WorkspaceController } from '@workspace/workspace-core';
 import { Button } from '@equinor/eds-core-react';
+import { ICellRendererParams } from 'ag-grid-community';
 const StyledApp = styled.div`
  background-color: ${tokens.colors.ui.background__default.hex};
  height: 100%;
@@ -48,9 +49,21 @@ interface Controllers<T>{
 }
 
 
+const CustomCellRender = (props: unknown) => {
+  return (
+    <div>
+      hello
+    </div>
+  )
+}
+
+
+
 function createGridController(){
   const gridController = new GridController();
-  gridController.columnDefs = [{field: "id", resizable: true, sortable: true},{field: "title", resizable: true, sortable: true},{field: "sequenceNumber", resizable: true, sortable: true},{field: "description", resizable: true, sortable: true} ]
+  gridController.columnDefs = [{field: "id", resizable: true, sortable: true, cellRenderer: (cell: ICellRendererParams) => {
+      return `SCR-${cell.value}`
+  }},{field: "title", resizable: true, sortable: true},{field: "sequenceNumber", resizable: true, sortable: true},{field: "description", resizable: true, sortable: true} ]
 
   return gridController;
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,7 +19,8 @@
       "@workspace/garden": ["packages/garden/src/index.ts"],
       "@workspace/power-bi": ["packages/power-bi/src/index.ts"],
       "@workspace/table": ["packages/table/src/index.ts"],
-      "@workspace/workspace": ["packages/workspace/src/index.ts"]
+      "@workspace/workspace": ["packages/workspace/src/index.ts"],
+      "@workspace/grid": ["packages/ag-grid/src/index.ts"]
     },
     "noImplicitAny": false,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
# Description

AG-Grid package pretty much does everything we need. The only thing that is hard is persisting the configuration of the current view. Ag grid makes a controller/API on mount when the onGridReady callback is called. However if you store the grid's API in a variable and reference it after the grid has unmounted you get a warning saying that the grid has been destroyed because the view unmounted. The hard part is writing a controller that mirrors the grid's API in a good way. Preventing the grid's API from destroying itself seems like a futile effort towards a hacky solution.

For now most of the important state like rowData, column definitions etc are stored in a controller. But down the line we will probably face some issues with this. Specifically regarding bookmarks/viewSettings/localstorage etc..


Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read.
- [x] Documentation and comments is added where needed.
- [x] My code is covered by tests.
