### PR TITLE
Improve typing for workspace core controllers

### DIFF
--- a/packages/workspace-core/src/lib/controllers/workspaceController.ts
+++ b/packages/workspace-core/src/lib/controllers/workspaceController.ts
@@ -40,7 +40,7 @@ export class WorkspaceController<TData, TControllers extends Record<string, any>
     getFilteredData = () => this.filteredData;
     getData = () => this.data;
     getContext = () => this.context;
-    addController = <TController>(controller: Controller<TController,WorkspaceController<TData, TControllers, TOnClick, TError, TContext>>) => addController(controller, this)
+    addController = <TController>(controller: Controller<TController,WorkspaceController<TData, TControllers, TOnClick, TError, TContext>, TControllers>) => addController(controller, this)
     addMiddleware = (middleware: MiddlewareConfigFunction<this>) => middleware(this);
     setContext = (context: ContextCallbackSetter<TContext | undefined>) => (this.context = context(this.context));
     setData = (data: TData[], preventCallbacks?: boolean) => (this.data = data) && !preventCallbacks && this.notifyOnDataChangedCallbacks();

--- a/packages/workspace-core/src/lib/functions/addController.ts
+++ b/packages/workspace-core/src/lib/functions/addController.ts
@@ -15,7 +15,7 @@ export function addController<
     TOnClick,
     TError,
     TContext
->>,
+>, TControllers>,
     workspaceController: WorkspaceController<
         TData,
         TControllers,

--- a/packages/workspace-core/src/lib/types/types.ts
+++ b/packages/workspace-core/src/lib/types/types.ts
@@ -8,8 +8,8 @@ export type ConfigFunction<TController, WSController> = (
 
 export type MiddlewareConfigFunction<WSController> = (controller: WSController) => void;
 
-export interface Controller<TControllerType, WSController> {
-    name: string;
+export interface Controller<TControllerType, WSController, TControllers> {
+    name: keyof TControllers;
     controller: TControllerType;
     config?: ConfigFunction<TControllerType, WSController>;
 }


### PR DESCRIPTION
# Description
Adding a controller to the workspace core module you should/need to specify an interface for the controller type. Allowing you to do workspaceController.controllers.grid and it will be the correct typings. But when invoking the addController method you just supply a name that could be completely unrelated to the interface provided. With this improvement you will get intellisense for all the keys in the interface

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read.
- [x] Documentation and comments is added where needed.
- [ ] My code is covered by tests.
