### PR TITLE
Fix missing generic type in useSidesheet hook

### DIFF
--- a/packages/sidesheet/src/lib/hooks/useSidesheet.ts
+++ b/packages/sidesheet/src/lib/hooks/useSidesheet.ts
@@ -7,4 +7,4 @@ interface Sidesheet<TItem>{
     item: TItem | undefined
 }
 
-export const useSidesheet = <T>(controller: SidesheetController<T>): Sidesheet<T> => ({isOpen: useSidesheetState(controller), item: useSidesheetItem(controller)})
+export const useSidesheet = <T>(controller: SidesheetController<T, unknown>): Sidesheet<T> => ({isOpen: useSidesheetState(controller), item: useSidesheetItem(controller)})


### PR DESCRIPTION
# Description
useSidesheet was missing a generic type, set to unknown because the generic is context and the hook reflects no such value.

Completes: AB#FILL_IN_YOUR_ISSUE_ID


## Type of change

Remove options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Checklist

- [x] My code follows the style guidelines of this project
- [x]  I have performed a self-review of my own code.
- [ ] I have linked my DevOps task using the AB# tag.
- [x] My code is easy to read.
- [x] Documentation and comments is added where needed.
- [ ] My code is covered by tests.

