### PR TITLE
add min length 1 to status bar and grid array args

### DIFF
--- a/packages/workspace-fusion/src/lib/types/configuration.ts
+++ b/packages/workspace-fusion/src/lib/types/configuration.ts
@@ -1,4 +1,4 @@
-import { StatusBar, StatusItem } from '@equinor/status-bar';
+import { StatusItem } from '@equinor/status-bar';
 import { ColDef, GridOptions } from 'ag-grid-community';
 import { WorkspaceOnClick } from './onClick';
 

--- a/packages/workspace-fusion/src/lib/types/configuration.ts
+++ b/packages/workspace-fusion/src/lib/types/configuration.ts
@@ -1,9 +1,9 @@
-import { StatusItem } from '@equinor/status-bar';
+import { StatusBar, StatusItem } from '@equinor/status-bar';
 import { ColDef, GridOptions } from 'ag-grid-community';
 import { WorkspaceOnClick } from './onClick';
 
 export interface GridConfig<T> {
-	columnDefinitions: ColDef<T>[];
+	columnDefinitions: [ColDef<T>, ...ColDef<T>[]];
 	gridOptions?: GridOptions<T>;
 }
 
@@ -19,4 +19,4 @@ interface StatusBar<TData> {
 	getValue: GetStatusItem<TData>;
 }
 
-export type StatusBarConfig<TData> = StatusBar<TData>[];
+export type StatusBarConfig<TData> = [StatusBar<TData>, ...StatusBar<TData>[]];


### PR DESCRIPTION
# Description
Typing now requires a minimum of 1 object in the array for it not to throw type error

I.E
s.columnDefinitions = [] //Type error
s.columnDefintions = [{field: "id"}] //OK
s.columnDefintions = [{field: "id"}, {field: "description"}] //OK


## Type of change

Remove options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)

