### PR TITLE
feat: :sparkles: add tabs based on async predicate

### DIFF
--- a/packages/handover/src/lib/components/HandoverApp.tsx
+++ b/packages/handover/src/lib/components/HandoverApp.tsx
@@ -59,6 +59,12 @@ const createWorkspaceController = (client: HttpClientMsal) => {
 			])
 			.addGrid(gridOptions)
 			.addCustomTab(customTab)
+			.addCustomTab({
+				Component: () => <div>Admin page</div>,
+				name: 'Admin',
+				TabIcon: () => <div>Admin</div>,
+				predicate: async () => new Promise((res) => setTimeout(() => res(true), 5000)),
+			})
 			.addConfig({
 				appColor: 'purple',
 				appKey: 'Handover',

--- a/packages/workspace-fusion/src/lib/types/configuration.ts
+++ b/packages/workspace-fusion/src/lib/types/configuration.ts
@@ -36,6 +36,11 @@ export type CustomTab = {
 	TabIcon: () => JSX.Element;
 	Component: CustomTabComponent;
 	CustomHeader?: () => JSX.Element;
+	/**
+	 * Will add the tab if the async function returns true
+	 * e.g access checks for conditional rendering
+	 */
+	predicate?: () => Promise<boolean>;
 };
 
 export type AppConfig<TabNames extends string> = {

--- a/packages/workspace-fusion/src/lib/utils/addCustomTab.tsx
+++ b/packages/workspace-fusion/src/lib/utils/addCustomTab.tsx
@@ -2,15 +2,16 @@ import { WorkspaceViewController } from '@equinor/workspace-react';
 import { CustomTabWrapper } from '../components';
 import { CustomTab, FusionMediator, WorkspaceTabNames } from '../types';
 
-export function addCustomTab<TData, TError>(
-	{ Component, TabIcon, name, CustomHeader }: CustomTab,
+export async function addCustomTab<TData, TError>(
+	tab: CustomTab,
 	viewController: WorkspaceViewController<WorkspaceTabNames, TError>,
 	mediator: FusionMediator<TData>
 ) {
-	viewController.tabController.addTab({
-		Component: () => <CustomTabWrapper Component={Component} mediator={mediator} />,
-		TabIcon,
-		CustomHeader,
-		name: name as WorkspaceTabNames,
+	if (!tab.predicate || !(await tab.predicate())) return;
+	viewController.tabController.tabs.push({
+		Component: () => <CustomTabWrapper Component={tab.Component} mediator={mediator} />,
+		TabIcon: tab.TabIcon,
+		CustomHeader: tab.CustomHeader,
+		name: tab.name as WorkspaceTabNames,
 	});
 }

--- a/packages/workspace-fusion/src/lib/utils/addCustomTab.tsx
+++ b/packages/workspace-fusion/src/lib/utils/addCustomTab.tsx
@@ -7,7 +7,7 @@ export async function addCustomTab<TData, TError>(
 	viewController: WorkspaceViewController<WorkspaceTabNames, TError>,
 	mediator: FusionMediator<TData>
 ) {
-	if (!tab.predicate || !(await tab.predicate())) return;
+	if (tab.predicate && !(await tab.predicate())) return;
 	viewController.tabController.tabs.push({
 		Component: () => <CustomTabWrapper Component={tab.Component} mediator={mediator} />,
 		TabIcon: tab.TabIcon,


### PR DESCRIPTION
# Description
Allows for adding of custom tabs based on async predicate e.g have to check rights before the tab is added.
Example admin tab

Completes: [AB#32861](https://statoil-proview.visualstudio.com/9949ad5e-7d15-4531-901e-296574079ee1/_workitems/edit/32861)

## Type of change

Remove options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactor (A code change that neither fixes a bug nor adds a feature)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read.
-   [ ] Documentation and comments is added where needed.
-   [ ] My code is covered by tests.
-   [ ] UX has reviewed relevant UI contributions.
