### PR TITLE
chore(garden): update generic types on fieldsettings type

### DIFF
--- a/packages/garden/src/lib/classes/gardenController.ts
+++ b/packages/garden/src/lib/classes/gardenController.ts
@@ -42,7 +42,7 @@ export class GardenController<
 	/** Grouping keys for garden */
 	grouping = new ReactiveValue<GroupingKeys<TData>>({ horizontalGroupingAccessor: '', verticalGroupingKeys: [] });
 
-	fieldSettings: FieldSettings<TData, TCustomGroupByKeys, string> = {};
+	fieldSettings: FieldSettings<TData, string, TCustomGroupByKeys> = {};
 
 	/** Function that takes in an item and returns the string to be shown on the garden package */
 	nodeLabelCallback: NodeLabelCallback<TData>;

--- a/packages/garden/src/lib/types/config.ts
+++ b/packages/garden/src/lib/types/config.ts
@@ -2,12 +2,12 @@ import { GardenController } from '../classes';
 import { GetIdentifier } from '../classes';
 import { GroupingKeys, FieldSettings, OnClickEvents, NodeLabelCallback, BaseRecordObject } from './';
 
-export interface GardenConfig<
+export type GardenConfig<
 	TData,
 	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = BaseRecordObject<unknown>,
 	TCustomState extends BaseRecordObject<TCustomState> = BaseRecordObject<unknown>,
 	TContext = unknown
-> {
+> = {
 	/** Data to be used for the garden */
 	data: TData[];
 	/** Primary(Unique) identifier for the data */
@@ -20,11 +20,11 @@ export interface GardenConfig<
 	/** The keys used for grouping when the garden loads initially */
 	initialGrouping: GroupingKeys<TData>;
 	/** The available keys to be used for grouping */
-	fieldSettings?: FieldSettings<TData, TCustomGroupByKeys, string>;
+	fieldSettings?: FieldSettings<TData, string, TCustomGroupByKeys>;
 	customGroupByKeys?: TCustomGroupByKeys;
 	/** Supply functions for handling clicks in the garden */
 	clickEvents?: OnClickEvents<TData, TCustomGroupByKeys, TCustomState, TContext>;
 
 	getCustomState?: (data: TData[]) => TCustomState;
 	configFunction?: (controller: GardenController<TData, TCustomGroupByKeys, TCustomState, TContext>) => void;
-}
+};

--- a/packages/garden/src/lib/types/fieldSettings.ts
+++ b/packages/garden/src/lib/types/fieldSettings.ts
@@ -3,16 +3,18 @@ import { BaseRecordObject } from './customGeneric';
 export type GetSortFunction = (a: string, b: string) => number;
 export type GetKeyFunction<
 	TData,
-	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = BaseRecordObject<unknown>
-> = (item: TData, itemKey: keyof TData | string, customGroupByKeys?: TCustomGroupByKeys) => string[] | string;
+	TExtendedFields extends string = never,
+	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = never
+> = (item: TData, itemKey: keyof TData | TExtendedFields, customGroupByKeys: TCustomGroupByKeys) => string[] | string;
 
 export type FieldSetting<
 	ItemType,
-	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = BaseRecordObject<unknown>
+	TExtendedFields extends string,
+	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys>
 > = {
 	key?: keyof ItemType | string;
 	label?: string;
-	getKey?: GetKeyFunction<ItemType, TCustomGroupByKeys>;
+	getKey?: GetKeyFunction<ItemType, TExtendedFields, TCustomGroupByKeys>;
 	getColumnSort?: GetSortFunction;
 };
 
@@ -27,6 +29,6 @@ export type FieldSetting<
  */
 export type FieldSettings<
 	ItemType,
-	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = BaseRecordObject<unknown>,
-	ExtendedFields extends string = never
-> = Partial<Record<keyof ItemType | ExtendedFields, FieldSetting<ItemType, TCustomGroupByKeys>>>;
+	ExtendedFields extends string = never,
+	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = never
+> = Partial<Record<keyof ItemType | ExtendedFields, FieldSetting<ItemType, ExtendedFields, TCustomGroupByKeys>>>;

--- a/packages/garden/src/lib/types/fieldSettings.ts
+++ b/packages/garden/src/lib/types/fieldSettings.ts
@@ -5,7 +5,7 @@ export type GetKeyFunction<
 	TData,
 	TExtendedFields extends string = never,
 	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = never
-> = (item: TData, itemKey: keyof TData | TExtendedFields, customGroupByKeys: TCustomGroupByKeys) => string[] | string;
+> = (item: TData, itemKey: keyof TData | TExtendedFields, customGroupByKeys?: TCustomGroupByKeys) => string[] | string;
 
 export type FieldSetting<
 	ItemType,

--- a/packages/garden/src/lib/utils/groupBy.ts
+++ b/packages/garden/src/lib/utils/groupBy.ts
@@ -1,19 +1,16 @@
 import { BaseRecordObject, FieldSettings, GardenGroup, GardenGroups, GroupDescriptionFunc } from '../types';
 import { PreGroupByFiltering } from '../types';
 
-interface GroupByArgs<
-	TData,
-	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = BaseRecordObject<unknown>
-> {
+type GroupByArgs<TData, TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = BaseRecordObject<unknown>> = {
 	arr: TData[];
 	keys: string[];
 	groupDescriptionFunc?: GroupDescriptionFunc<TData>;
-	fieldSettings?: FieldSettings<TData, TCustomGroupByKeys, string>;
+	fieldSettings?: FieldSettings<TData, string, TCustomGroupByKeys>;
 	isExpanded?: boolean;
 	preGroupFiltering: PreGroupByFiltering<TData>;
 	customGroupByKeys?: TCustomGroupByKeys;
 	depth: number;
-}
+};
 
 const lookupGroup = <T>(acc: GardenGroups<T>, valueKey: string): GardenGroup<T> | undefined => {
 	return acc.find((x) => x.value === valueKey);
@@ -109,16 +106,16 @@ export function groupBy<
 	return gardengroups;
 }
 
-interface GroupByArrayArgs<
+type GroupByArrayArgs<
 	TData,
 	TCustomGroupByKeys extends BaseRecordObject<TCustomGroupByKeys> = BaseRecordObject<unknown>
-> {
+> = {
 	arr: TData[];
 	key: keyof TData | string;
 	preGroupFiltering: (arr: TData[], groupByKey: string) => TData[];
-	fieldSettings?: FieldSettings<TData, TCustomGroupByKeys, string>;
+	fieldSettings?: FieldSettings<TData, string, TCustomGroupByKeys>;
 	isExpanded?: boolean;
-}
+};
 
 function groupByArray<
 	TData,


### PR DESCRIPTION
# Description
Updating the generic types on Fieldsettings type to improve typesafety on `getKey` function. 
`ExtendedFields` generic on `FieldSettings` was only placed in the wrong order.

When defining a fieldSettings object you now should add a third generic parameter `CustomGroupByKeys` which results in:
```ts
getKey: (item, itemKey, customGroupByKeys) 
```
being typed correctly. If generic parameter is not added, the type of the parameters will be never.

Example:
```ts
export const fieldSettings: FieldSettings<
  HandoverPackage,
  ExtendedGardenFields,
  HandoverCustomGroupByKeys
> = {
  RFCC: { label: 'RFCC', getKey: getDateKey, getColumnSort: sortByNumber },
  TAC: { label: 'TAC', getKey: getDateKey, getColumnSort: sortByNumber },
  RFOC: { label: 'RFOC', getKey: getDateKey, getColumnSort: sortByNumber },
  DCC: { label: 'DCC', getKey: getDateKey, getColumnSort: sortByNumber },
  RFRC: { label: 'RFRC', getKey: getDateKey, getColumnSort: sortByNumber },
  responsible: { label: 'Comm Pkg Responsible' },
  area: { label: 'Comm Pkg Area' },
  phase: { label: 'Comm Pkg Phase' },
  progress: {
    label: 'Comm Pkg Progress',
    getKey: getProgressKey,
    getColumnSort: sortByNumber,
  },
  system: { label: 'System' },
  priority1: { label: 'Commissioning Priority 1' },
  priority2: { label: 'Commissioning Priority 2' },
  priority3: { label: 'Commissioning Priority 3' },
};
```
where HandoverCustomGroupByKeys is
```ts
export type HandoverCustomGroupByKeys = {
  weeklyDaily: 'Weekly' | 'Daily';
  plannedForecast: 'Planned' | 'Forecast';
};
```

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] Refactor (A code change that neither fixes a bug nor adds a feature)


## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [x] My code is easy to read.
-   [x] Documentation and comments is added where needed.
-   [ ] My code is covered by tests.
-   [ ] UX has reviewed relevant UI contributions.
