### PR TITLE
chore: define create mode in sidesheet advanced config

### DIFF
--- a/packages/workspace-fusion/src/lib/integrations/sidesheet/components/addSidesheet.tsx
+++ b/packages/workspace-fusion/src/lib/integrations/sidesheet/components/addSidesheet.tsx
@@ -25,11 +25,11 @@ export function addSidesheet<
 		mediator.sidesheetService.sendEvent(ev);
 	});
 
-	if (config.type === 'advanced') {
+	if (config.type === 'custom') {
 		viewController.addSidesheetComponent(() => <SidesheetAdvancedWrapper config={config} mediator={mediator} />);
 		return;
 	}
-	if (config.type === 'simple') {
+	if (config.type === 'default') {
 		viewController.addSidesheetComponent(() => <SidesheetSimpleWrapper config={config} mediator={mediator} />);
 		return;
 	}

--- a/packages/workspace-fusion/src/lib/integrations/sidesheet/sidesheet.ts
+++ b/packages/workspace-fusion/src/lib/integrations/sidesheet/sidesheet.ts
@@ -19,7 +19,7 @@ export const CreateSidesheetConfigKey: keyof SidesheetSimple<any> = 'CreateSides
 export type SimpleProps<T extends Record<PropertyKey, unknown> = {}> = T & { controller: Controller };
 
 export type SidesheetSimple<TData extends Record<PropertyKey, unknown>> = {
-	type: 'simple';
+	type: 'default';
 	DetailsSidesheet?: (props: SimpleProps<DetailsSidesheetProps<TData>>) => JSX.Element;
 	CreateSidesheet?: (props: SimpleProps) => JSX.Element;
 };
@@ -29,7 +29,8 @@ export type SidesheetAdvanced<
 	TContext extends Record<PropertyKey, unknown>,
 	TCustomSidesheetEvents extends BaseEvent
 > = {
-	type: 'advanced';
+	type: 'custom';
+	hasCreateSidesheet?: boolean;
 	Sidesheet?: (props: SidesheetProps<TData, TContext, TCustomSidesheetEvents>) => JSX.Element;
 };
 


### PR DESCRIPTION
# Description

If custom/advanced sidesheet mode is enabled there is no way to determine if create sidesheet is present

Please include a summary of the change and which issue is fixed.
List any external dependencies that are required for this change.

Completes: AB#FILL_IN_YOUR_ISSUE_ID

## Type of change

Remove options that are not relevant.

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Refactor (A code change that neither fixes a bug nor adds a feature)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist

-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code.
-   [ ] I have linked my DevOps task using the AB# tag.
-   [ ] My code is easy to read.
-   [ ] Documentation and comments is added where needed.
-   [ ] My code is covered by tests.
-   [ ] UX has reviewed relevant UI contributions.
