### PR TITLE
unique key warning

### DIFF
--- a/packages/workspace-fusion/src/lib/integrations/common/components/TabNavigation.tsx
+++ b/packages/workspace-fusion/src/lib/integrations/common/components/TabNavigation.tsx
@@ -2,6 +2,7 @@ import { useActiveTab, useControllerContext } from '@equinor/workspace-react';
 import { WorkspaceTabNames } from '../../../types';
 import { TabButtonDivider, TabButtonList, TabButton } from '../../../components/Header';
 import { useWorkspaceHeaderComponents } from '../../../context/WorkspaceHeaderComponents';
+import { Fragment } from 'react';
 
 export const TabNavigation = () => {
 	const { icons, analyticsTabs, viewTabs } = useWorkspaceHeaderComponents();
@@ -16,8 +17,10 @@ export const TabNavigation = () => {
 		<TabButtonList>
 			{!!leftIcons.length && (
 				<>
-					{leftIcons.map(({ Icon }) => (
-						<Icon />
+					{leftIcons.map(({ Icon, name }) => (
+						<Fragment key={name}>
+							<Icon />
+						</Fragment>
 					))}
 					<TabButtonDivider />
 				</>
@@ -28,6 +31,7 @@ export const TabNavigation = () => {
 					{analyticsTabs.map((s) => (
 						<TabButton
 							isActive={s.name === activeTab?.name}
+							key={s.name}
 							onClick={() => tabController.setActiveTab(s.name as WorkspaceTabNames)}
 						>
 							<s.TabIcon />
@@ -54,8 +58,10 @@ export const TabNavigation = () => {
 
 			{!!rightIcons.length && (
 				<>
-					{rightIcons.map(({ Icon }) => (
-						<Icon />
+					{rightIcons.map(({ Icon, name }) => (
+						<Fragment key={name}>
+							<Icon />
+						</Fragment>
 					))}
 				</>
 			)}


### PR DESCRIPTION
# Description

React writes a warning in the console when the results of a map operation does not contain the key attribute.
The warning is given due to performance impacts which doesnt really apply in this case, but it's an easy fix

Closes #262 

Addresses: AB#FILL_IN_YOUR_ISSUE_ID

## Checklist

-   [x] My code follows the style guidelines of this project
-   [ ] Documentation and comments is added where needed.
-   [ ] My code is covered by tests.
-   [ ] UX has reviewed relevant UI contributions.


## Definition of Done
- [x] PR title and description are to the point and understandable
- [x] I have performed a self-review of my own code
