### PR TITLE
fix: :bug: fix title on expanded filter item

### DIFF
--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-filter",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/filter/src/lib/components/expandedFilterItem/ExpandedFilterItem.tsx
+++ b/packages/filter/src/lib/components/expandedFilterItem/ExpandedFilterItem.tsx
@@ -32,7 +32,7 @@ export const ExpandedFilterItem = ({
 
   return (
     <StyledFilterItemWrap
-      title={typeof filterItem === 'string' ? filterItem : '(Blank)'}
+      title={filterItem.value ?? '(Blank)'}
       style={{
         position: 'absolute',
         top: 0,

--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
Old: When hover on a filter when filter is expandend, it always said "blank"

New: When hover on a filter when filter is expandend, it says the filtername or "blank" if its missing value