### PR TITLE
feat: 💄 add support for more quickfilters

### DIFF
--- a/apps/test-app/src/index.tsx
+++ b/apps/test-app/src/index.tsx
@@ -91,7 +91,7 @@ function getFilterMetaData(num_filters: number = 2): any[] {
     filterData.push({
       filterItems: items,
       isQuickFilter: true,
-      name: `Filter ${filterName}`,
+      name: `system 2 Filter ${filterName}`,
     });
   }
 
@@ -116,7 +116,7 @@ function getKPIData(num_kpis = 5) {
 
 let GARDEN_SIZE = 30;
 let GRID_SIZE = 150;
-let FILTER_SIZE = 5;
+let FILTER_SIZE = 10;
 let KPI_SIZE = 10;
 const GardenBlockData = getGardenBlockData(GARDEN_SIZE);
 

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-filter",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/filter/src/lib/components/filterGroup/FilterGroup.tsx
+++ b/packages/filter/src/lib/components/filterGroup/FilterGroup.tsx
@@ -40,7 +40,7 @@ export const FilterGroup = ({
 
   if (filterItems.length === 0) return <></>;
   return (
-    <div>
+    <div style={{ width: 'fit-content' }}>
       <StyledFilterGroupWrapper ref={ref} onClick={onClick}>
         {isFetching ? (
           <Skeleton height={24} width={100} />

--- a/packages/filter/src/lib/components/quickFilter/QuickFilter.tsx
+++ b/packages/filter/src/lib/components/quickFilter/QuickFilter.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import {
+  QuickFilterGroupsLayout,
   StyledCompactFilterWrapper,
   StyledLeftSection,
   StyledRightSection,
@@ -86,25 +87,24 @@ const QuickFilterReady = ({ groups }: QuickFilterReadyProps) => {
           <StyledRightSection>
             {!isFilterExpanded && (
               <>
-                {quickFilterGroups.map(
-                  (group, i) =>
-                    i < 5 && (
-                      <FilterGroup
-                        isFetching={query.isFetching}
-                        uncheckedValues={uncheckedValues.find((s) => s.name === group.name)?.values ?? []}
-                        onClick={() => handleExpandFilterGroup(group.name)}
-                        group={group}
-                        key={group.name}
-                        isOpen={filterGroupOpen === group.name}
-                        name={group.name}
-                        isMonospace={
-                          !!monospaceGroups.find(
-                            (value) => value.trim().toLowerCase() === group.name.trim().toLowerCase()
-                          )
-                        }
-                      />
-                    )
-                )}
+                <QuickFilterGroupsLayout>
+                  {quickFilterGroups.map((group, i) => (
+                    <FilterGroup
+                      isFetching={query.isFetching}
+                      uncheckedValues={uncheckedValues.find((s) => s.name === group.name)?.values ?? []}
+                      onClick={() => handleExpandFilterGroup(group.name)}
+                      group={group}
+                      key={group.name}
+                      isOpen={filterGroupOpen === group.name}
+                      name={group.name}
+                      isMonospace={
+                        !!monospaceGroups.find(
+                          (value) => value.trim().toLowerCase() === group.name.trim().toLowerCase()
+                        )
+                      }
+                    />
+                  ))}
+                </QuickFilterGroupsLayout>
                 <FiltersAppliedInfo activeFilters={calculateHiddenFiltersApplied()} />
               </>
             )}

--- a/packages/filter/src/lib/components/quickFilter/quickFilter.styles.ts
+++ b/packages/filter/src/lib/components/quickFilter/quickFilter.styles.ts
@@ -20,6 +20,18 @@ export const StyledRightSection = styled.div`
   gap: 2em;
   align-items: center;
   padding-right: 0.5rem;
+  width: 100%;
+`;
+
+export const QuickFilterGroupsLayout = styled.div`
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(auto-fit, minmax(max-content, 100px));
+  grid-template-rows: 1fr;
+  height: 48px;
+  direction: rtl;
+  gap: 20px;
+  align-items: center;
 `;
 
 export const StyledSearchLine = styled.div`

--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
A prior issue was that we had to set a max amount of quickfilters to ensure the ui didnt break when overflowing. Added some responsive css that autofills the amount of available space with quickfilters