### PR TITLE
fix:scrollbar disappearing

### DIFF
--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "6.0.13",
+  "version": "6.0.14",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/workspace-react/package.json
+++ b/packages/workspace-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-react",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/workspace-react/src/lib/components/Workspace.tsx
+++ b/packages/workspace-react/src/lib/components/Workspace.tsx
@@ -38,15 +38,13 @@ export function Workspace({ tabs, defaultTab, Sidesheet = () => <></>, providers
         <TabsProvider.Provider value={tabs}>
           <EventHandler {...events}>
             <ContextProviders providers={providers}>
-              <StyledSidesheetWrapper>
-                <StyledLayoutWrapper>
-                  <WorkspaceHeader />
-                  <WorkspaceBody />
-                  <StyledSurroundingSidesheet id="sidesheet-workspace-wrapper">
-                    <Sidesheet />
-                  </StyledSurroundingSidesheet>
-                </StyledLayoutWrapper>
-              </StyledSidesheetWrapper>
+              <StyledLayoutWrapper>
+                <WorkspaceHeader />
+                <WorkspaceBody />
+                <StyledSidesheetWrapper id="sidesheet-workspace-wrapper">
+                  <Sidesheet />
+                </StyledSidesheetWrapper>
+              </StyledLayoutWrapper>
             </ContextProviders>
           </EventHandler>
         </TabsProvider.Provider>
@@ -55,7 +53,7 @@ export function Workspace({ tabs, defaultTab, Sidesheet = () => <></>, providers
   );
 }
 
-const StyledSurroundingSidesheet = styled.div`
+const StyledSidesheetWrapper = styled.div`
   grid-area: 1 / 2 / span 2;
   background: white;
   z-index: 2;
@@ -67,13 +65,6 @@ const StyledLayoutWrapper = styled.div`
   grid-template-columns: 1fr auto;
   height: 100%;
   width: 100%;
-`;
-
-const StyledSidesheetWrapper = styled.div`
-  height: 100%;
-  width: 100%;
-  display: grid;
-  grid-template-columns: minmax(0px, 1fr) auto; /* set two equal-width columns */
 `;
 
 const EventHandler = (props: PropsWithChildren<WorkspaceEvents>) => {


### PR DESCRIPTION
Fix a bug where the bottom scrollbar in garden would disappear when opening the sidesheet. Bug was caused by remnant styling. Didnt catch the bug as it doesnt happen on 4k widescreens, only on smaller screens
