### PR TITLE
fix(garden): :bug: added condition for rendering of viewsettings

### DIFF
--- a/packages/garden/package.json
+++ b/packages/garden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-garden",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/garden/src/lib/components/Garden.tsx
+++ b/packages/garden/src/lib/components/Garden.tsx
@@ -76,7 +76,7 @@ export function Garden<TData extends Record<PropertyKey, unknown>, TContext = un
 }: GardenProps<TData, TContext>): JSX.Element | null {
   const client = useRef(new QueryClient());
   const [groupingKeys, setGroupingKeys] = useState<string[]>(initialGrouping);
-
+  const [isLoading, setIsLoading] = useState(true);
   const [timeInterval, updateTimeInterval] = useState<string | null>(initialTimeInterval ?? null);
   const onChangetimeInterval = (timeInterval: string | null) => {
     updateTimeInterval(timeInterval);
@@ -116,12 +116,8 @@ export function Garden<TData extends Record<PropertyKey, unknown>, TContext = un
               customViews={customViews}
               visuals={visuals}
             >
-              <VirtualContainer context={context as TContext} dataSource={dataSource} />
-            </GardenConfigProvider>
-
-            {
-              // Hides ViewSettings sidebar when sidesheet is open
-              selected ? null : (
+              <VirtualContainer context={context as TContext} dataSource={dataSource} setIsLoading={setIsLoading} />
+              {selected || isLoading ? null : (
                 <ViewSettings
                   dateVariant={dateVariant}
                   groupingKeys={groupingKeys}
@@ -130,8 +126,8 @@ export function Garden<TData extends Record<PropertyKey, unknown>, TContext = un
                   onChangeTimeInterval={onChangetimeInterval}
                   setGroupingKeys={setGroupingKeys}
                 />
-              )
-            }
+              )}
+            </GardenConfigProvider>
           </GardenContextProvider>
         </Suspense>
       </ErrorBoundary>

--- a/packages/garden/src/lib/components/VirtualContainer/VirtualContainer.tsx
+++ b/packages/garden/src/lib/components/VirtualContainer/VirtualContainer.tsx
@@ -1,24 +1,27 @@
+import { Icon } from '@equinor/eds-core-react';
+import { info_circle } from '@equinor/eds-icons';
+import { useEffect } from 'react';
+import styled from 'styled-components';
 import { useItemWidths } from '../../hooks';
 import { useGarden } from '../../hooks/useGarden';
 import { useGardenConfig } from '../../hooks/useGardenConfig';
 import { ExpandProvider } from '../ExpandProvider';
 import { GardenDataSource } from '../Garden';
 import { VirtualGarden } from '../VirtualGarden';
-import { StyledVirtualContainer } from './virtualContainer.styles';
-import { info_circle } from '@equinor/eds-icons';
-import { Icon } from '@equinor/eds-core-react';
-import styled from 'styled-components';
 import { SplashScreen } from '../splashScreen/SplashScreen';
+import { StyledVirtualContainer } from './virtualContainer.styles';
 Icon.add({ info_circle });
 
 type VirtualContainerProps<TContext = undefined> = {
   dataSource: GardenDataSource<TContext>;
   context: TContext;
+  setIsLoading: (isLoading: boolean) => void;
 };
 
 export const VirtualContainer = <TContext,>({
   dataSource,
   context,
+  setIsLoading,
 }: VirtualContainerProps<TContext>): JSX.Element | null => {
   const { onClickItem } = useGardenConfig();
   const { gardenMetaQuery } = useGarden();
@@ -26,6 +29,10 @@ export const VirtualContainer = <TContext,>({
   if (gardenMetaQuery.isLoading) {
     return <SplashScreen />;
   }
+
+  useEffect(() => {
+    if (!gardenMetaQuery.isLoading) setIsLoading(false);
+  }, [gardenMetaQuery.isLoading]);
 
   if (!gardenMetaQuery.data) {
     // Will never happen when suspense is true

--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "7.0.3",
+  "version": "7.0.4",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
Dont render viewsettings before virtual garden is init. this prevents the sidebar from moving around