### PR TITLE
🐛 : Fixed cramped filter columns in QuickFilters

### DIFF
--- a/packages/power-bi/package.json
+++ b/packages/power-bi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-powerbi",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/power-bi/src/lib/components/QuickFilter/QuickFilter.tsx
+++ b/packages/power-bi/src/lib/components/QuickFilter/QuickFilter.tsx
@@ -103,10 +103,14 @@ const StyledFilterButtons = styled.div`
 const StyledQuickFilterWrapper = styled.div`
   display: grid;
   width: 100%;
-  justify-content: flex-end;
-  grid-template-columns: repeat(auto-fit, minmax(60px, max-content));
-  gap: 2em;
+  justify-content: flex-start;
+  grid-template-columns: repeat(auto-fit, minmax(max-content, 50px));
   grid-template-rows: 1fr;
+  gap: 10px;
+  align-items: center;
+  overflow-x: hidden;
+  padding-left: 10px;
+  padding-right: 10px;
 `;
 
 const FilterButtonContainer = styled.div`

--- a/packages/power-bi/src/lib/components/quickFilterGroup/QuickFilterGroup.tsx
+++ b/packages/power-bi/src/lib/components/quickFilterGroup/QuickFilterGroup.tsx
@@ -24,8 +24,9 @@ export const PowerBiFilterGroup = ({
 
   if (!activeFilters) return null;
   const isAllChecked = activeFilters.length === 0 || activeFilters.length === group.filterVals.length;
+
   return (
-    <div style={{ height: '50px', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+    <>
       <StyledFilterGroupWrapper onClick={() => setIsOpen((s) => !s)} ref={anchorEl}>
         <div>
           {getFilterHeaderText(
@@ -48,6 +49,6 @@ export const PowerBiFilterGroup = ({
           onCloseMenu={() => setIsOpen(false)}
         />
       )}
-    </div>
+    </>
   );
 };

--- a/packages/power-bi/src/lib/components/quickFilterGroup/quickFilterGroup.styles.ts
+++ b/packages/power-bi/src/lib/components/quickFilterGroup/quickFilterGroup.styles.ts
@@ -2,12 +2,12 @@ import { tokens } from '@equinor/eds-tokens';
 import styled from 'styled-components';
 
 export const StyledFilterGroupWrapper = styled.div`
-  height: auto;
-  width: auto;
+  height: 50px;
+  width: min-content;
   display: flex;
   align-items: center;
   cursor: pointer;
-
+  justify-content: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
Fixed issue with cramped filters in QuickFilters.
Modified grid to scale according to the filter column content.

fixes: equinor/cc-components#813