### PR TITLE
fix(power-bi): :bug: Quick filter dropdowns now close when clicking outside popover

### DIFF
--- a/packages/power-bi/package.json
+++ b/packages/power-bi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-powerbi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/power-bi/src/lib/components/quickFilterGroup/QuickFilterGroup.tsx
+++ b/packages/power-bi/src/lib/components/quickFilterGroup/QuickFilterGroup.tsx
@@ -1,6 +1,7 @@
 import { Icon } from '@equinor/eds-core-react';
 import { tokens } from '@equinor/eds-tokens';
-import { useState, useRef } from 'react';
+import { useRef, useState } from 'react';
+import styled from 'styled-components';
 import { ActiveFilter, PowerBiFilter, PowerBiFilterItem } from '../../types';
 import { getFilterHeaderText } from '../../utils/getFilterHeader';
 import { FilterController } from '../Filter/Filter';
@@ -27,6 +28,7 @@ export const PowerBiFilterGroup = ({
 
   return (
     <>
+      {isOpen && <StyledOverlay onClick={() => setIsOpen(false)} />}
       <StyledFilterGroupWrapper onClick={() => setIsOpen((s) => !s)} ref={anchorEl}>
         <StyledFilterGroupContent>
           <div>
@@ -54,3 +56,13 @@ export const PowerBiFilterGroup = ({
     </>
   );
 };
+
+// Overlay to close the popover when clicking outside it
+const StyledOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 999;
+`;

--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
### Short summary
Added an overlay to close popover when clicking outside the popover

Link to issue:
https://github.com/equinor/cc-reports/issues/140

### PR Checklist

- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [x] I have linked related issue to the PR
- [x] I have bumped the version(s) in the changed package(s)
- [x] I have bumped the version in workspace-fusion

> [!TIP]
> You can test your changes on the test-application. You can find it under apps\test-app\src\index.tsx

> [!CAUTION]
> ⛔ I understand by merging my PR, the changed packages will be published to NPM immediately ⛔
