### PR TITLE
fix(power-bi): :lipstick: Set max height for power-bi reports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,10 @@
 {
-	"conventionalCommits.scopes": ["Workspace-react", "all", "garden"],
+	"conventionalCommits.scopes": [
+		"Workspace-react",
+		"all",
+		"garden",
+		"power-bi"
+	],
 	"markdownlint.config": {
 		"MD033": {
 			"allowed_elements": ["a", "p", "img"]

--- a/packages/power-bi/package.json
+++ b/packages/power-bi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-powerbi",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/power-bi/src/lib/components/loadedReport/LoadedReport.tsx
+++ b/packages/power-bi/src/lib/components/loadedReport/LoadedReport.tsx
@@ -42,6 +42,7 @@ export const LoadedReport = ({ config, onReportReady }: LoadedReportProps) => {
 
 const StyledAspectRatio = styled.div<{ width: number }>`
   height: ${({ width }) => `${defaultAspectRatio * width}px`};
+  max-height: calc(100% - 5px);
 `;
 
 const PowerBiWrapper = styled.div.attrs({

--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "9.0.4",
+  "version": "9.0.5",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
### Short summary
Set max height for power-bi reports

Link to issue:
https://github.com/equinor/cc-reports/issues/171

### PR Checklist

- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [x] I have linked related issue to the PR
- [x] I have bumped the version(s) in the changed package(s)
- [x] I have bumped the version in workspace-fusion

> [!TIP]
> You can test your changes on the test-application. You can find it under apps\test-app\src\index.tsx

> [!CAUTION]
> ⛔ I understand by merging my PR, the changed packages will be published to NPM immediately ⛔
