### PR TITLE
fix: access denied message not showing

### DIFF
--- a/packages/power-bi/package.json
+++ b/packages/power-bi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-powerbi",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/power-bi/src/lib/components/report/Report.tsx
+++ b/packages/power-bi/src/lib/components/report/Report.tsx
@@ -16,7 +16,7 @@ const StyledLoadingWrapper = styled.div`
 `;
 
 export function Report({ getEmbedInfo, getToken, reportUri, controller, filters, bookmark }: PowerBiProps) {
-  const { data: token, isLoading: isTokenLoading } = useQuery<FusionPowerBiToken>({
+  const { data: token, isLoading: isTokenLoading, error: tokenError } = useQuery<FusionPowerBiToken>({
     queryKey: [reportUri, 'token'],
     queryFn: ({ signal }) => getToken(reportUri, signal),
     refetchInterval: (query) => generateRefetchInterval(query.state.data),
@@ -24,7 +24,7 @@ export function Report({ getEmbedInfo, getToken, reportUri, controller, filters,
     refetchOnWindowFocus: true,
   });
 
-  const { data: embed, isLoading: isEmbedLoading } = useQuery({
+  const { data: embed, isLoading: isEmbedLoading, error: embedError } = useQuery({
     queryKey: [reportUri, 'embed'],
     queryFn: async ({ signal }) => {
       const { embedUrl, reportId } = await getEmbedInfo(reportUri, '', signal);
@@ -43,12 +43,12 @@ export function Report({ getEmbedInfo, getToken, reportUri, controller, filters,
     );
   }
 
-  if (!embed) {
-    throw new Error('No embed');
+  if (!embed || embedError) {
+    throw embedError ?? new Error("Failed to get embed")
   }
 
-  if (!token) {
-    throw new Error('No token');
+  if (!token || tokenError) {
+    throw tokenError ?? new Error('Failed to get token');
   }
 
   return (
@@ -98,3 +98,4 @@ const defaultEmbedConfiguration: IReportEmbedConfiguration = {
   type: 'report',
   tokenType: 1,
 };
+;

--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "9.0.7",
+  "version": "9.0.8",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
When combining the embed and token api call in the previous pr #624. I forgot to handle the errors and propagate them to the error boundary