### PR TITLE
fix(workspace): Hide export to excel button if not configured

### DIFF
--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "9.0.8",
+  "version": "9.0.9",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/workspace-fusion/src/modules/grid/components/GridWrapper.tsx
+++ b/packages/workspace-fusion/src/modules/grid/components/GridWrapper.tsx
@@ -62,7 +62,9 @@ export const GridWrapper = <
       placement: 'right',
       type: 'button',
     };
-    setIcons((s) => [...s, icon]);
+    if (config.excelExport) {
+      setIcons((s) => [...s, icon]);
+    }
 
     return () => {
       setIcons((s) => s.filter((y) => y.name !== icon.name));


### PR DESCRIPTION
### Short summary
Hide export to excel button if not configured

Link to issue:
https://github.com/equinor/cc-components/issues/852

### PR Checklist

- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [x] I have linked related issue to the PR
- [x] I have bumped the version(s) in the changed package(s)
- [x] I have bumped the version in workspace-fusion

> [!TIP]
> You can test your changes on the test-application. You can find it under apps\test-app\src\index.tsx

> [!CAUTION]
> ⛔ I understand by merging my PR, the changed packages will be published to NPM immediately ⛔
