### PR TITLE
feat(handover): Added grouping to status bar

### DIFF
--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "9.0.8",
+  "version": "9.0.9",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/workspace-fusion/src/lib/integrations/status-bar/components/StatusBar.tsx
+++ b/packages/workspace-fusion/src/lib/integrations/status-bar/components/StatusBar.tsx
@@ -1,6 +1,6 @@
 import { StatusItem } from '../types/statusItem';
 import { StatusBarItem } from './StatusBarItem';
-import { StyledStatusBar } from './statusBar.styles';
+import { StyledStatusBar, StyledStatusBarDivider } from './statusBar.styles';
 
 interface StatusBarProps {
   items: StatusItem[];
@@ -9,10 +9,43 @@ interface StatusBarProps {
 export function StatusBar({ items }: StatusBarProps): JSX.Element | null {
   if (!items.length) return null;
 
+  // Check if all items are in the same group
+  if (items.every((i) => i.group === items[0].group)) {
+    return (
+      <StyledStatusBar id="status_bar_root">
+        {items.map((item) => (
+          <StatusBarItem key={item.title} item={item} />
+        ))}
+      </StyledStatusBar>
+    );
+  }
+
+  // Group items by their 'group' property
+  const groupedItems = items.reduce(
+    (groups, item) => {
+      const group = groups[item.group ?? ''] || [];
+      group.push(item);
+      groups[item.group ?? ''] = group;
+      return groups;
+    },
+    {} as Record<string, StatusBarProps['items']>
+  );
+
+  // Render each group with its items
   return (
     <StyledStatusBar id="status_bar_root">
-      {items.map((item) => (
-        <StatusBarItem key={item.title} item={item} />
+      {Object.entries(groupedItems).map(([groupName, groupItems], i) => (
+        <>
+          {i !== 0 && (
+            <>
+              <StyledStatusBarDivider></StyledStatusBarDivider>
+              {!groupName ? <></> : <div style={{ alignSelf: 'center' }}>{groupName}:</div>}
+            </>
+          )}
+          {groupItems.map((item) => (
+            <StatusBarItem key={item.title} item={item} />
+          ))}
+        </>
       ))}
     </StyledStatusBar>
   );

--- a/packages/workspace-fusion/src/lib/integrations/status-bar/components/statusBar.styles.ts
+++ b/packages/workspace-fusion/src/lib/integrations/status-bar/components/statusBar.styles.ts
@@ -6,3 +6,11 @@ export const StyledStatusBar = styled.div`
   padding-left: 1rem;
   align-items: flex-end;
 `;
+
+export const StyledStatusBarDivider = styled.div`
+  height: auto;
+  align-self: stretch;
+  border-left: 1px solid #dcdcdc;
+  color: #3d3d3d;
+  margin: 8px 0;
+`;

--- a/packages/workspace-fusion/src/lib/integrations/status-bar/types/statusItem.ts
+++ b/packages/workspace-fusion/src/lib/integrations/status-bar/types/statusItem.ts
@@ -4,4 +4,5 @@ export interface StatusItem {
   /** Value to be shown in the status bar */
   value: string | number;
   description?: string;
+  group?: string;
 }


### PR DESCRIPTION
### Short summary
Added grouping option to status bar

Link to issue:
https://github.com/equinor/cc-components/issues/1035

### PR Checklist

- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [x] I have linked related issue to the PR
- [x] I have bumped the version(s) in the changed package(s)
- [x] I have bumped the version in workspace-fusion

> [!TIP]
> You can test your changes on the test-application. You can find it under apps\test-app\src\index.tsx

> [!CAUTION]
> ⛔ I understand by merging my PR, the changed packages will be published to NPM immediately ⛔
