### PR TITLE
feat: Align headers across gardens

### DIFF
--- a/packages/garden/package.json
+++ b/packages/garden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-garden",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",

--- a/packages/garden/src/lib/components/defaultComponents/header/DefaultHeaderView.tsx
+++ b/packages/garden/src/lib/components/defaultComponents/header/DefaultHeaderView.tsx
@@ -3,19 +3,35 @@ import { memo } from 'react';
 import styled from 'styled-components';
 import { tokens } from '@equinor/eds-tokens';
 
-const Count = styled.span`
+const StyledHeaderContent = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+`;
+
+const StyledCount = styled.h2`
   color: ${tokens.colors.text.static_icons__default.hex};
   font-weight: 300;
   font-size: 0.8rem;
   margin-left: 0.8em;
 `;
 
-const HeaderView = ({ header }: CustomHeaderView) => {
+const StyledHeaderText = styled.h2`
+  white-space: pre-line;
+  font-size: 16px;
+  text-align: center;
+`;
+
+const HeaderView = (props: CustomHeaderView) => {
+  const { header } = props;
+
   return (
-    <>
-      {header.name}
-      <Count>({header.count})</Count>
-    </>
+    <StyledHeaderContent>
+      <StyledHeaderText>{header.name}</StyledHeaderText>
+      <StyledCount>({header.count})</StyledCount>
+    </StyledHeaderContent>
   );
 };
 

--- a/packages/workspace-fusion/package.json
+++ b/packages/workspace-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/workspace-fusion",
-  "version": "9.0.14",
+  "version": "9.0.15",
   "type": "module",
   "sideEffects": false,
   "license": "MIT",


### PR DESCRIPTION
### Short summary
Updates the default garden header that is now used across all gardens

Link to issue:
Closes https://github.com/equinor/cc-components/issues/853

### PR Checklist

- [x] I have performed a self-review of my own code
- [x] I have written a short summary of my changes in the PR
- [x] I have linked related issue to the PR
- [x] I have bumped the version(s) in the changed package(s)
- [x] I have bumped the version in workspace-fusion

> [!TIP]
> You can test your changes on the test-application. You can find it under apps\test-app\src\index.tsx

> [!CAUTION]
> ⛔ I understand by merging my PR, the changed packages will be published to NPM immediately ⛔
